### PR TITLE
add function to compute pval from gamma-fit to trials ...

### DIFF
--- a/skyllh/core/analysis_utils.py
+++ b/skyllh/core/analysis_utils.py
@@ -90,6 +90,10 @@ def calculate_pval_from_trials(
         The ndarray holding the test-statistic values of the trials.
     ts_threshold : float
         The critical test-statistic value.
+
+    Returns
+    -------
+    p, p_sigma: tuple(float, float)
     """
     p = ts_vals[ts_vals > ts_threshold].size / ts_vals.size
     p_sigma = np.sqrt(p * (1 - p) / ts_vals.size)
@@ -118,7 +122,7 @@ def calculate_pval_from_gammafit_to_trials(ts_vals, ts_threshold,
 
     Returns
     -------
-    p, p_err: tuple(float, float)
+    p, p_sigma: tuple(float, float)
     """
     if(ts_threshold <  eta):
         raise ValueError(
@@ -181,7 +185,7 @@ def calculate_pval_from_trials_mixed(ts_vals, ts_threshold, switch_at_ts=5.0,
 
     Returns
     -------
-    p, p_err: tuple(float, float)
+    p, p_sigma: tuple(float, float)
     """
     if ts_threshold < switch_at_ts:
         return calculate_pval_from_trials(ts_vals, ts_threshold)

--- a/skyllh/core/analysis_utils.py
+++ b/skyllh/core/analysis_utils.py
@@ -170,7 +170,7 @@ def calculate_pval_from_gammafit_to_trials(ts_vals, ts_threshold,
     return (p, p_sigma)
 
 
-def calculate_pval_from_trials_mixed(ts_vals, ts_threshold, switch_at_ts=5.0,
+def calculate_pval_from_trials_mixed(ts_vals, ts_threshold, switch_at_ts=3.0,
         eta=None, n_max=500000, comp_operator='greater_equal'):
     """Calculates the probability (p-value) of test-statistic exceeding
     the given test-statistic threshold. This calculation relies on fitting


### PR DESCRIPTION
... to core/analysis_utils.py supplementing the existing direct calculation ( https://github.com/icecube/skyllh/blob/82d158ac96008befe6583aa4020079bb4dfd9190/skyllh/core/analysis_utils.py#L80 ).

Also add a function that switches between pvalue from trials and pvalue from fit methods depending on value of ts.
If similar functionality exists elsewhere, please close.