### PR TITLE
Fix `mu_fluxes` indexing in `mu2flux` method

### DIFF
--- a/skyllh/core/signal_generator.py
+++ b/skyllh/core/signal_generator.py
@@ -185,6 +185,7 @@ class SignalGenerator(object):
         mu_fluxes = np.empty((n_sources,), dtype=np.float)
 
         shg_list = self._src_hypo_group_manager.src_hypo_group_list
+        mu_fluxes_idx_offset = 0
         for (shg_idx,shg) in enumerate(shg_list):
             fluxmodel = shg.fluxmodel
             # Calculate conversion factor from the flux model unit into the
@@ -195,7 +196,8 @@ class SignalGenerator(object):
                         (self._sig_candidates['shg_src_idx'] == k))
                 ref_N_k = np.sum(self._sig_candidates[mask]['weight']) * ref_N
                 mu_flux_k = mu / ref_N * (ref_N_k / ref_N) * fluxmodel.Phi0*toGeVcm2s
-                mu_fluxes[shg_idx*k] = mu_flux_k
+                mu_fluxes[mu_fluxes_idx_offset + k] = mu_flux_k
+            mu_fluxes_idx_offset += shg.n_sources
 
         if(per_source):
             return mu_fluxes


### PR DESCRIPTION
The `mu_fluxes[shg_idx*k] = mu_flux_k` array indexing was incorrect for multiple sources/source hypothesis groups. It affected the `mu2flux` method in stacking analyses. This PR fixes the issue.