### PR TITLE
add setup and version file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,51 @@
+[metadata]
+name = skyllh
+description =The SkyLLH framework is an open-source Python3-based package licensed under the GPLv3 license. It provides a modular framework for implementing custom likelihood functions and executing log-likelihood ratio hypothesis tests. The idea is to provide a class structure tied to the mathematical objects of the likelihood functions, rather than to entire abstract likelihood models.
+long_description = file:README.md
+long_description_content_type = text/markdown
+url = https://github.com/grburgess/popsynth
+author_email = XXXXXXX
+author = XXXXX
+requires_python = >=3.8.0
+license = GPL-3+
+
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Environment :: Console
+    Intended Audience :: Science/Research
+    License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)
+    Operating System :: POSIX
+    Programming Language :: Python :: 3.8
+    Topic :: Scientific/Engineering :: Physics
+
+project_urls =
+    Bug Tracker = https://github.com/icecube/skyllh/issues
+    Source Code = https://github.com/icecube/skyllh
+
+
+[options]
+packages = find:
+install_requires =
+    astropy
+    numpy
+    scipy
+    iminuit
+    matplotlib
+    
+
+
+tests_require =
+    pytest
+    pytest-codecov
+
+
+[tool:pytest]
+# Options for py.test:
+# Specify command line options as you would do when invoking py.test directly.
+# e.g. --cov-report html (or xml) for html/xml output or --junitxml junit.xml
+# in order to write a coverage file that can be read by Jenkins.
+addopts = --color=yes --cov=skyllh --cov-report=term -ra --ignore=test --ignore=skyllh/_version.py
+log_cli = 1
+log_cli_level = INFO
+testpaths = test 
+norecursedirs = test

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ name = skyllh
 description =The SkyLLH framework is an open-source Python3-based package licensed under the GPLv3 license. It provides a modular framework for implementing custom likelihood functions and executing log-likelihood ratio hypothesis tests. The idea is to provide a class structure tied to the mathematical objects of the likelihood functions, rather than to entire abstract likelihood models.
 long_description = file:README.md
 long_description_content_type = text/markdown
-url = https://github.com/grburgess/popsynth
+url = https://github.com/icecube/skyllh
 author_email = XXXXXXX
 author = XXXXX
 requires_python = >=3.8.0

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,15 @@
+from setuptools import setup
+
+
+ver_file = {}
+
+with open("skyllh/_version.py") as f:
+
+    exec(f.read(), ver_file)
+
+
+setup(
+    version=ver_file["_version"],
+#    include_package_data=True,
+#    package_data={"": extra_files},
+)

--- a/skyllh/__init__.py
+++ b/skyllh/__init__.py
@@ -5,3 +5,9 @@ import logging
 # Initialize top-level logger with a do-nothing NullHandler. It is required to
 # be able to log messages when user has not set up any handler for the logger.
 logging.getLogger(__name__).addHandler(logging.NullHandler())
+
+
+from ._version import get_version
+
+__version__ = get_version()
+del get_version

--- a/skyllh/_version.py
+++ b/skyllh/_version.py
@@ -1,0 +1,9 @@
+_version = "22.04.28a"
+
+
+def get_version() -> str:
+    """
+    This is over simplified but without a versioning system, the best way at the moment.
+    """
+
+    return _version


### PR DESCRIPTION
This adds a setup file and version file so that the package can be installed without modifying the system path which is dangerous and can lead to crossed paths during execution. There are better ways to do versioning, but without knowing the versioning system used, this is the quickest solution. Also, the version system will not work with PyPi.

Now that there is a proper setup file, it is relatively easy to release on PyPi with a GitHub action. This would require adopting a better versioning system, and dropping the letters in the version names. I am happy to add this as well. 