### PR TITLE
Numpy dtype fixes

### DIFF
--- a/examples/scrambling.py
+++ b/examples/scrambling.py
@@ -7,7 +7,7 @@ from skyllh.core.scrambling import DataScrambler, RAScramblingMethod
 
 def gen_data(rss, N=100, window=(0,365)):
     """Create uniformly distributed data on sphere. """
-    arr = np.empty((N,), dtype=[("ra", np.float), ("dec", np.float)])
+    arr = np.empty((N,), dtype=[("ra", np.float64), ("dec", np.float64)])
 
     arr["ra"] = rss.random.uniform(0., 2.*np.pi, N)
     arr["dec"] = rss.random.uniform(-np.pi, np.pi, N)

--- a/skyllh/core/analysis.py
+++ b/skyllh/core/analysis.py
@@ -778,12 +778,12 @@ class Analysis(object, metaclass=abc.ABCMeta):
         # Create the structured array data type for the result array.
         result_dtype = [
             ('seed', np.int64),
-            ('mean_n_sig', np.float),
+            ('mean_n_sig', np.float64),
             ('n_sig', np.int64),
-            ('mean_n_sig_0', np.float),
-            ('ts', np.float)
+            ('mean_n_sig_0', np.float64),
+            ('ts', np.float64)
         ] + [
-            (fitparam_name, np.float)
+            (fitparam_name, np.float64)
                 for fitparam_name in fitparamset.fitparam_name_list
         ]
         result = np.empty((1,), dtype=result_dtype)

--- a/skyllh/core/analysis.py
+++ b/skyllh/core/analysis.py
@@ -777,9 +777,9 @@ class Analysis(object, metaclass=abc.ABCMeta):
 
         # Create the structured array data type for the result array.
         result_dtype = [
-            ('seed', np.int),
+            ('seed', np.int64),
             ('mean_n_sig', np.float),
-            ('n_sig', np.int),
+            ('n_sig', np.int64),
             ('mean_n_sig_0', np.float),
             ('ts', np.float)
         ] + [

--- a/skyllh/core/analysis_utils.py
+++ b/skyllh/core/analysis_utils.py
@@ -64,8 +64,11 @@ def pointlikesource_to_data_field_array(
 
     arr = np.empty(
         (len(sources),),
-        dtype=[('ra', np.float), ('dec', np.float),
-               ('src_w', np.float), ('src_w_grad', np.float), ('src_w_W', np.float)]
+        dtype=[('ra', np.float64),
+               ('dec', np.float64),
+               ('src_w', np.float64),
+               ('src_w_grad', np.float64),
+               ('src_w_W', np.float64)]
               , order='F')
 
     for (i, src) in enumerate(sources):
@@ -1048,7 +1051,7 @@ def generate_mu_of_p_spline_interpolation(
     # Make a mu(p) spline via interp1d.
     # The interp1d function requires unique x values. So we need to sort the
     # p_vals in increasing order and mask out repeating p values.
-    p_mu_vals = np.array(sorted(zip(p_vals, mu_vals)), dtype=np.float)
+    p_mu_vals = np.array(sorted(zip(p_vals, mu_vals)), dtype=np.float64)
     p_vals = p_mu_vals[:,0]
     unique_pval_mask = np.concatenate(([True], np.invert(
         p_vals[1:] <= p_vals[:-1])))
@@ -1159,7 +1162,7 @@ def create_trial_data_file(
 
         mean_n_sig = np.arange(
             mean_n_sig_min, mean_n_sig_max+1, mean_n_sig_step,
-            dtype=np.float)
+            dtype=np.float64)
 
     if(not isinstance(mean_n_sig_null, np.ndarray)):
         if(not issequence(mean_n_sig_null)):
@@ -1181,7 +1184,7 @@ def create_trial_data_file(
 
         mean_n_sig_null = np.arange(
             mean_n_sig_null_min, mean_n_sig_null_max+1, mean_n_sig_null_step,
-            dtype=np.float)
+            dtype=np.float64)
 
     pbar = ProgressBar(
         len(mean_n_sig)*len(mean_n_sig_null), parent=ppbar).start()

--- a/skyllh/core/coords.py
+++ b/skyllh/core/coords.py
@@ -59,7 +59,7 @@ def rotate_spherical_vector(ra1, dec1, ra2, dec2, ra3, dec3):
 
     # Calculate the rotation matrix R_i for each event i and perform the
     # rotation on vector 3 for each event.
-    vec = np.empty((N_event,3), dtype=np.float)
+    vec = np.empty((N_event,3), dtype=np.float64)
 
     sin_alpha = np.sin(alpha)
     twopi = 2*np.pi

--- a/skyllh/core/interpolate.py
+++ b/skyllh/core/interpolate.py
@@ -178,7 +178,7 @@ class NullGridManifoldInterpolationMethod(GridManifoldInterpolationMethod):
 
         value = self._f(tdm, gridparams, eventdata)
         gradients = np.zeros(
-            (len(params), tdm.n_selected_events), dtype=np.float)
+            (len(params), tdm.n_selected_events), dtype=np.float64)
 
         return (value, gradients)
 

--- a/skyllh/core/livetime.py
+++ b/skyllh/core/livetime.py
@@ -281,7 +281,7 @@ class Livetime(object):
 
         # Mask odd indices as on-time (True) MJD values and even indices as
         # off-time (False).
-        is_on = np.array(onoff_idxs & 0x1, dtype=np.bool)
+        is_on = np.array(onoff_idxs & 0x1, dtype=np.bool_)
 
         return is_on
 
@@ -304,7 +304,10 @@ class Livetime(object):
         # Create bin array with only on-time bins. We have to mask out the
         # off-time bins.
         ontime_bins = np.diff(self._onoff_intervals)
-        mask = np.invert(np.array(np.linspace(0,ontime_bins.size-1,ontime_bins.size)%2, dtype=np.bool))
+        mask = np.invert(
+            np.array(
+                np.linspace(0, ontime_bins.size-1, ontime_bins.size)%2,
+                dtype=np.bool_))
         ontime_bins = ontime_bins[mask]
 
         # Create the cumulative array of the on-time bins.

--- a/skyllh/core/livetime.py
+++ b/skyllh/core/livetime.py
@@ -201,7 +201,8 @@ class Livetime(object):
         # The t_start_idx and t_end_idx variables hold even indices.
         N_ontime_intervals = int((t_end_idx - t_start_idx)/2)
 
-        ontime_intervals_flat = np.empty((N_ontime_intervals*2,), dtype=np.float)
+        ontime_intervals_flat = np.empty(
+            (N_ontime_intervals*2,), dtype=np.float64)
         # Set the first and last on-time interval edges.
         ontime_intervals_flat[0] = t_start
         ontime_intervals_flat[-1] = t_end

--- a/skyllh/core/llhratio.py
+++ b/skyllh/core/llhratio.py
@@ -495,7 +495,7 @@ class ZeroSigH0SingleDatasetTCLLHRatio(SingleDatasetTCLLHRatio):
                     np.count_nonzero(unstablemask)))
 
         # Allocate memory for the log_lambda_i values.
-        log_lambda_i = np.empty_like(alpha_i, dtype=np.float)
+        log_lambda_i = np.empty_like(alpha_i, dtype=np.float64)
 
         # Calculate the log_lambda_i value for the numerical stable events.
         log_lambda_i[stablemask] = np.log1p(alpha_i[stablemask])
@@ -507,14 +507,14 @@ class ZeroSigH0SingleDatasetTCLLHRatio(SingleDatasetTCLLHRatio):
         log_lambda = np.sum(log_lambda_i) + (N - Nprime)*np.log1p(-ns/N)
 
         # Calculate the gradient for each fit parameter.
-        grads = np.empty((dXi_ps.shape[0]+1,), dtype=np.float)
+        grads = np.empty((dXi_ps.shape[0]+1,), dtype=np.float64)
 
         # Pre-calculate value that is used twice for the gradients of the
         # numerical stable events.
         one_over_one_plus_alpha_i_stablemask = 1 / (1 + alpha_i[stablemask])
 
         # For ns.
-        nsgrad_i = np.empty_like(alpha_i, dtype=np.float)
+        nsgrad_i = np.empty_like(alpha_i, dtype=np.float64)
         nsgrad_i[stablemask] = Xi[stablemask] * one_over_one_plus_alpha_i_stablemask
         nsgrad_i[unstablemask] = (1 - tildealpha_i)*Xi[unstablemask] / one_plus_alpha
         # Cache the nsgrad_i values for a possible later calculation of the
@@ -694,11 +694,11 @@ class SingleSourceZeroSigH0SingleDatasetTCLLHRatio(
             logger.debug('dtype(Xi)={:s}'.format(str(Xi.dtype)))
 
         # Calculate the gradients of Xi for each fit parameter (without ns).
-        dXi_ps = np.empty((len(fitparam_values)-1,len(Xi)), dtype=np.float)
+        dXi_ps = np.empty((len(fitparam_values)-1,len(Xi)), dtype=np.float64)
         for (idx, fitparam_value) in enumerate(fitparam_values[1:]):
             fitparam_name = self._src_fitparam_mapper.get_src_fitparam_name(idx)
 
-            dRi = np.zeros((len(Xi),), dtype=np.float)
+            dRi = np.zeros((len(Xi),), dtype=np.float64)
             for (num_k) in np.arange(len(pdfratioarray._pdfratio_list)):
                 # Get the PDFRatio instance from which we need the derivative from.
                 pdfratio = pdfratioarray.get_pdfratio(num_k)
@@ -1041,9 +1041,9 @@ class SingleSourceDatasetSignalWeights(DatasetSignalWeights):
         N_datasets = self.n_datasets
         N_fitparams = self._src_fitparam_mapper.n_global_fitparams
 
-        Y = np.empty((N_datasets,), dtype=np.float)
+        Y = np.empty((N_datasets,), dtype=np.float64)
         if(N_fitparams > 0):
-            Y_grads = np.empty((N_datasets, N_fitparams), dtype=np.float)
+            Y_grads = np.empty((N_datasets, N_fitparams), dtype=np.float64)
 
         # Loop over the detector signal efficiency instances for the first and
         # only source hypothesis group.
@@ -1134,9 +1134,9 @@ class MultiSourceDatasetSignalWeights(SingleSourceDatasetSignalWeights):
         N_datasets = self.n_datasets
         N_fitparams = self._src_fitparam_mapper.n_global_fitparams
 
-        Y = np.empty((N_datasets, len(self._src_arr_list[0])), dtype=np.float)
+        Y = np.empty((N_datasets, len(self._src_arr_list[0])), dtype=np.float64)
         if(N_fitparams > 0):
-            Y_grads = np.empty((N_datasets, len(self._src_arr_list[0]), N_fitparams), dtype=np.float)
+            Y_grads = np.empty((N_datasets, len(self._src_arr_list[0]), N_fitparams), dtype=np.float64)
 
         # Loop over the detector signal efficiency instances for the first and
         # only source hypothesis group.
@@ -1563,13 +1563,14 @@ class MultiDatasetTCLLHRatio(TCLLHRatio):
         # Allocate an array for the gradients of the composite log-likelihood
         # function. It is always at least one element long, i.e. the gradient
         # for ns.
-        grads = np.zeros((len(fitparam_values),), dtype=np.float)
+        grads = np.zeros((len(fitparam_values),), dtype=np.float64)
 
         # Create an array holding the fit parameter values for a particular
         # llh ratio function. Since we need to adjust ns with nsj it's more
         # efficient to create this array once and use it within the for loop
         # over the llh ratio functions.
-        llhratio_fitparam_values = np.empty((len(fitparam_values),), dtype=np.float)
+        llhratio_fitparam_values = np.empty(
+            (len(fitparam_values),), dtype=np.float64)
         # Loop over the llh ratio functions.
         for (j, llhratio) in enumerate(self._llhratio_list):
             if(tracing):
@@ -1624,9 +1625,10 @@ class MultiDatasetTCLLHRatio(TCLLHRatio):
 
         nsf = ns * self._cache_f
 
-        nsgrad2j = np.empty((len(self._llhratio_list),), dtype=np.float)
+        nsgrad2j = np.empty((len(self._llhratio_list),), dtype=np.float64)
         # Loop over the llh ratio functions and their second derivative.
-        llhratio_fitparam_values = np.empty((len(fitparam_values),), dtype=np.float)
+        llhratio_fitparam_values = np.empty(
+            (len(fitparam_values),), dtype=np.float64)
         for (j, llhratio) in enumerate(self._llhratio_list):
             llhratio_fitparam_values[0] = nsf[j]
             llhratio_fitparam_values[1:] = fitparam_values[1:]
@@ -1718,7 +1720,7 @@ class NsProfileMultiDatasetTCLLHRatio(TCLLHRatio):
 
         # Compute the constant log-likelihood function value for the
         # null-hypothesis.
-        fitparam_values_0 = np.array([self._mean_n_sig_0], dtype=np.float)
+        fitparam_values_0 = np.array([self._mean_n_sig_0], dtype=np.float64)
         (self._logL_0, grads_0) = self._llhratio.evaluate(fitparam_values_0)
 
     def evaluate(self, fitparam_values):

--- a/skyllh/core/minimizer.py
+++ b/skyllh/core/minimizer.py
@@ -549,7 +549,7 @@ class NR1dNsMinimizerImpl(MinimizerImpl):
         ns_tol = self.ns_tol
 
         niter = 0
-        x = np.copy(initials).astype(np.float)
+        x = np.copy(initials).astype(np.float64)
         ns = x[0]
 
         # Initialize stepsize to be larger than ns tolerance.

--- a/skyllh/core/multiproc.py
+++ b/skyllh/core/multiproc.py
@@ -215,7 +215,7 @@ def parallelize(func, args_list, ncpu, rss=None, tl=None, ppbar=None):
 
     # Return result list if only one CPU is used.
     if(ncpu == 1):
-        sarr = np.zeros((1,), dtype=[('n_finished_tasks', np.int)])
+        sarr = np.zeros((1,), dtype=[('n_finished_tasks', np.int64)])
         result_list = master_wrapper(
             pbar, sarr, func, args_list, squeue=None, rss=rss, tl=tl)
 
@@ -286,7 +286,7 @@ def parallelize(func, args_list, ncpu, rss=None, tl=None, ppbar=None):
         logger.addHandler(orig_handler)
 
     # Compute the first chunk in the main process.
-    sarr = np.zeros((len(processes)+1,), dtype=[('n_finished_tasks', np.int)])
+    sarr = np.zeros((len(processes)+1,), dtype=[('n_finished_tasks', np.int64)])
     result_list_0 = master_wrapper(
         pbar, sarr, func, sub_args_list_list[0], squeue=squeue, rss=rss_list[0],
         tl=tl_list[0])

--- a/skyllh/core/optimize.py
+++ b/skyllh/core/optimize.py
@@ -217,7 +217,7 @@ class SpatialEventSelectionMethod(EventSelectionMethod, metaclass=abc.ABCMeta):
 
         arr = np.empty(
             (len(sources),),
-            dtype=[('ra', np.float), ('dec', np.float)],
+            dtype=[('ra', np.float64), ('dec', np.float64)],
             order='F')
 
         for (i, src) in enumerate(sources):

--- a/skyllh/core/parameters.py
+++ b/skyllh/core/parameters.py
@@ -447,7 +447,7 @@ class ParameterSet(object):
 
         # Define a (n_fixed_params,)-shaped ndarray holding the values of the
         # fixed parameters. This is for optimization purpose only.
-        self._fixed_param_values = np.empty((0,), dtype=np.float)
+        self._fixed_param_values = np.empty((0,), dtype=np.float64)
 
         # Add the initial Parameter instances.
         if(params is not None):
@@ -539,10 +539,10 @@ class ParameterSet(object):
         """
         floating_params = self.floating_params
         if(len(floating_params) == 0):
-            return np.empty((0,), dtype=np.float)
+            return np.empty((0,), dtype=np.float64)
         return np.array(
             [ param.initial
-             for param in floating_params ], dtype=np.float)
+             for param in floating_params ], dtype=np.float64)
 
     @property
     def floating_param_bounds(self):
@@ -551,10 +551,10 @@ class ParameterSet(object):
         """
         floating_params = self.floating_params
         if(len(floating_params) == 0):
-            return np.empty((0,2), dtype=np.float)
+            return np.empty((0,2), dtype=np.float64)
         return np.array(
             [ (param.valmin, param.valmax)
-             for param in floating_params ], dtype=np.float)
+             for param in floating_params ], dtype=np.float64)
 
     def __iter__(self):
         """Returns an iterator over the Parameter instances of this ParameterSet
@@ -675,7 +675,7 @@ class ParameterSet(object):
         self._floating_param_name_list = []
         self._fixed_param_name_to_idx = dict()
         self._floating_param_name_to_idx = dict()
-        self._fixed_param_values = np.empty((0,), dtype=np.float)
+        self._fixed_param_values = np.empty((0,), dtype=np.float64)
         for (pidx, param) in enumerate(self._params):
             pname = param.name
             if(pname in fix_params_keys):
@@ -747,7 +747,7 @@ class ParameterSet(object):
         self._floating_param_name_list = []
         self._fixed_param_name_to_idx = dict()
         self._floating_param_name_to_idx = dict()
-        self._fixed_param_values = np.empty((0,), dtype=np.float)
+        self._fixed_param_values = np.empty((0,), dtype=np.float64)
         for (pidx, param) in enumerate(self._params):
             pname = param.name
             if(pname in float_params_keys):
@@ -1219,7 +1219,7 @@ class ParameterGrid(object):
         if(not issequence(arr)):
             raise TypeError('The grid property must be a sequence!')
         if(not isinstance(arr, np.ndarray)):
-            arr = np.array(arr, dtype=np.float)
+            arr = np.array(arr, dtype=np.float64)
         if(arr.ndim != 1):
             raise ValueError('The grid property must be a 1D numpy.ndarray!')
         self._grid = self.round_to_nearest_grid_point(arr)
@@ -2113,7 +2113,7 @@ class FitParameterSet(object):
         global fit parameters.
         """
         return np.array([ fitparam.initial
-                         for fitparam in self._fitparams ], dtype=np.float)
+                         for fitparam in self._fitparams ], dtype=np.float64)
 
     @property
     def bounds(self):
@@ -2121,7 +2121,7 @@ class FitParameterSet(object):
         boundaries for all the global fit parameters.
         """
         return np.array([ (fitparam.valmin, fitparam.valmax)
-                         for fitparam in self._fitparams ], dtype=np.float)
+                         for fitparam in self._fitparams ], dtype=np.float64)
 
     def copy(self):
         """Creates a deep copy of this FitParameterSet instance.
@@ -2191,7 +2191,7 @@ class FitParameterSet(object):
             The ndarray holding the fit parameter values in the order that the
             fit parameters are defined.
         """
-        fitparam_values = np.empty_like(self._fitparams, dtype=np.float)
+        fitparam_values = np.empty_like(self._fitparams, dtype=np.float64)
         for (i, fitparam) in enumerate(self._fitparams):
             fitparam_values[i] = fitparam_dict[fitparam.name]
         return fitparam_values
@@ -2400,7 +2400,7 @@ class SingleSourceFitParameterMapper(SourceFitParameterMapper):
             return None
 
         fitparams_arr = np.array([tuple(fitparam_values)],
-                                 dtype=[ (name, np.float)
+                                 dtype=[ (name, np.float64)
                                         for name in self._src_param_names ])
         return fitparams_arr
 
@@ -2548,7 +2548,7 @@ class MultiSourceFitParameterMapper(SourceFitParameterMapper):
             return None
 
         fitparams_arr = np.empty((self.N_sources,),
-                                 dtype=[ (name, np.float)
+                                 dtype=[ (name, np.float64)
                                          for name in self._unique_src_param_names ])
 
         for src_idx in range(self.N_sources):

--- a/skyllh/core/parameters.py
+++ b/skyllh/core/parameters.py
@@ -429,7 +429,7 @@ class ParameterSet(object):
         """
         # Define the list of parameters.
         # Define the (n_params,)-shaped numpy array of Parameter objects.
-        self._params = np.empty((0,), dtype=np.object)
+        self._params = np.empty((0,), dtype=np.object_)
         # Define the (n_params,)-shaped numpy mask array that masks the fixed
         # parameters in the list of all parameters.
         self._params_fixed_mask = np.empty((0,), dtype=np.bool)
@@ -1269,7 +1269,7 @@ class ParameterGrid(object):
 
         floatD = value/self._delta - self._lower_bound/self._delta
         floatD = np.around(floatD, 9)
-        intD = floatD.astype(np.int)
+        intD = floatD.astype(np.int64)
 
         return (floatD, intD)
 
@@ -1465,7 +1465,7 @@ class ModelParameterMapper(object, metaclass=abc.ABCMeta):
         # The local model parameter names are the names used by the internal
         # math objects, like PDFs. Thus, the global parameter names can be
         # aliases of such local model parameter names.
-        self._model_param_names = np.empty((0,), dtype=np.object)
+        self._model_param_names = np.empty((0,), dtype=np.object_)
 
         # (N_params, N_models) shaped boolean ndarray defining what global
         # parameter maps to which model.
@@ -2084,7 +2084,7 @@ class FitParameterSet(object):
         """
         # Define the list of fit parameters.
         # Define the (N_fitparams,)-shaped numpy array of FitParameter objects.
-        self._fitparams = np.empty((0,), dtype=np.object)
+        self._fitparams = np.empty((0,), dtype=np.object_)
         # Define a list for the fit parameter names. This is for optimization
         # purpose only.
         self._fitparam_name_list = []
@@ -2231,7 +2231,7 @@ class SourceFitParameterMapper(object, metaclass=abc.ABCMeta):
         # Define the list of source parameter names, which map to the fit
         # parameters.
         # Define the (N_fitparams,)-shaped numpy array of str objects.
-        self._src_param_names = np.empty((0,), dtype=np.object)
+        self._src_param_names = np.empty((0,), dtype=np.object_)
 
     @property
     def fitparamset(self):
@@ -2434,7 +2434,7 @@ class MultiSourceFitParameterMapper(SourceFitParameterMapper):
         self._fit_param_2_src_mask = np.zeros((0, len(self.sources)), dtype=np.bool)
 
         # Define an array, which will hold the unique source parameter names.
-        self._unique_src_param_names = np.empty((0,), dtype=np.object)
+        self._unique_src_param_names = np.empty((0,), dtype=np.object_)
 
     @property
     def sources(self):

--- a/skyllh/core/parameters.py
+++ b/skyllh/core/parameters.py
@@ -432,7 +432,7 @@ class ParameterSet(object):
         self._params = np.empty((0,), dtype=np.object_)
         # Define the (n_params,)-shaped numpy mask array that masks the fixed
         # parameters in the list of all parameters.
-        self._params_fixed_mask = np.empty((0,), dtype=np.bool)
+        self._params_fixed_mask = np.empty((0,), dtype=np.bool_)
 
         # Define two lists for the parameter names. One for the fixed
         # parameters, and one for the floating parameters.
@@ -1470,7 +1470,7 @@ class ModelParameterMapper(object, metaclass=abc.ABCMeta):
         # (N_params, N_models) shaped boolean ndarray defining what global
         # parameter maps to which model.
         self._global_param_2_model_mask = np.zeros(
-            (0, len(self._models)), dtype=np.bool)
+            (0, len(self._models)), dtype=np.bool_)
 
     @property
     def name(self):
@@ -1686,7 +1686,7 @@ class SingleModelParameterMapper(ModelParameterMapper):
         self._model_param_names = np.concatenate(
             (self._model_param_names,[model_param_name]))
 
-        mask = np.ones((1,), dtype=np.bool)
+        mask = np.ones((1,), dtype=np.bool_)
         self._global_param_2_model_mask = np.vstack(
             (self._global_param_2_model_mask, mask))
 
@@ -1815,7 +1815,7 @@ class MultiModelParameterMapper(ModelParameterMapper):
                 'maps, cannot be empty!')
 
         # Get the list of model indices to which the parameter maps.
-        mask = np.zeros((self.n_models,), dtype=np.bool)
+        mask = np.zeros((self.n_models,), dtype=np.bool_)
         for ((midx,model), applied_model) in itertools.product(
                 enumerate(self._models), models):
             if(applied_model.id == model.id):
@@ -2431,7 +2431,8 @@ class MultiSourceFitParameterMapper(SourceFitParameterMapper):
 
         # (N_fitparams, N_sources) shaped boolean ndarray defining what fit
         # parameter applies to which source.
-        self._fit_param_2_src_mask = np.zeros((0, len(self.sources)), dtype=np.bool)
+        self._fit_param_2_src_mask = np.zeros(
+            (0, len(self.sources)), dtype=np.bool_)
 
         # Define an array, which will hold the unique source parameter names.
         self._unique_src_param_names = np.empty((0,), dtype=np.object_)
@@ -2488,7 +2489,7 @@ class MultiSourceFitParameterMapper(SourceFitParameterMapper):
         self._unique_src_param_names = np.unique(self._src_param_names)
 
         # Get the list of source indices for which the fit parameter applies.
-        mask = np.zeros((len(self.sources),), dtype=np.bool)
+        mask = np.zeros((len(self.sources),), dtype=np.bool_)
         for ((idx,src), applied_src) in itertools.product(enumerate(self.sources), sources):
             if(applied_src.id == src.id):
                 mask[idx] = True

--- a/skyllh/core/pdf.py
+++ b/skyllh/core/pdf.py
@@ -555,7 +555,7 @@ class PDFProduct(PDF, metaclass=abc.ABCMeta):
 
         N_events = prob.shape[0]
         fitparam_names = self.param_set.floating_param_name_list
-        grads = np.zeros((len(fitparam_names), N_events), dtype=np.float)
+        grads = np.zeros((len(fitparam_names), N_events), dtype=np.float64)
         for (pidx, fitparam_name) in enumerate(fitparam_names):
             # Calculate the gradient w.r.t. fitparam.
 
@@ -613,7 +613,7 @@ class PDFProduct(PDF, metaclass=abc.ABCMeta):
             n_ev = tdm.n_selected_events
             norm_w = src_w.sum()
 
-            grads_tot = np.zeros((len(fitparam_names), n_ev), dtype=np.float)
+            grads_tot = np.zeros((len(fitparam_names), n_ev), dtype=np.float64)
             for (pidx, fitparam_name) in enumerate(fitparam_names):
                 if src_ev_idxs is not None:
                     grad_i = scp.sparse.csr_matrix((grads[pidx], (ev_idxs, src_idxs)))
@@ -874,7 +874,7 @@ class MultiDimGridPDF(PDF):
                     n_dim = tdm.n_selected_events
                 else:
                     n_dim = eventdata.shape[0]
-                return np.ones((n_dim,), dtype=np.float)
+                return np.ones((n_dim,), dtype=np.float64)
 
         if(not callable(func)):
             raise TypeError(
@@ -1162,7 +1162,7 @@ class NDPhotosplinePDF(PDF):
                         n_dim = tdm.n_selected_events * n_src
                     else:
                         n_dim = len(tdm.src_ev_idxs[0])
-                return np.ones((n_dim,), dtype=np.float)
+                return np.ones((n_dim,), dtype=np.float64)
 
         if(not callable(func)):
             raise TypeError(
@@ -1230,7 +1230,7 @@ class NDPhotosplinePDF(PDF):
                 if tdm.src_ev_idxs is not None:
                     (src_idxs, ev_idxs) = tdm.src_ev_idxs
                     eventdata = np.empty(
-                        (len(ev_idxs), len(self._axes)), dtype=np.float)
+                        (len(ev_idxs), len(self._axes)), dtype=np.float64)
                     for (axis_idx, axis) in enumerate(self._axes):
                         axis_name = axis.name
                         if(axis_name in tdm):
@@ -1251,12 +1251,12 @@ class NDPhotosplinePDF(PDF):
 
                             axis_data = np.full(
                                 (len(ev_idxs),), params[axis_name],
-                                dtype=np.float)
+                                dtype=np.float64)
                         eventdata[:, axis_idx] = axis_data
 
             elif self.is_background_pdf:
                 eventdata = np.empty(
-                    (tdm.n_selected_events, len(self._axes)), dtype=np.float)
+                    (tdm.n_selected_events, len(self._axes)), dtype=np.float64)
 
                 for (axis_idx, axis) in enumerate(self._axes):
                     axis_name = axis.name
@@ -1273,7 +1273,7 @@ class NDPhotosplinePDF(PDF):
 
                         axis_data = np.full(
                             (tdm.n_selected_events,), params[axis_name],
-                            dtype=np.float)
+                            dtype=np.float64)
                 eventdata[:, axis_idx] = axis_data
         self__pdf_evaluate_simple = self._pdf.evaluate_simple
 
@@ -1292,7 +1292,7 @@ class NDPhotosplinePDF(PDF):
 
         with TaskTimer(tl, 'Get grads from photospline fit.'):
             self__param_set = self._param_set
-            grads = np.empty((self._n_fitparams, len(prob)), dtype=np.float)
+            grads = np.empty((self._n_fitparams, len(prob)), dtype=np.float64)
             # Loop through the fit parameters of this PDF and calculate their
             # derivative.
             for (fitparam_idx, fitparam_name) in enumerate(
@@ -1676,7 +1676,7 @@ class MultiDimGridPDFSet(PDF, PDFSet):
 
         # Create an array for the gradients, which will only contain the
         # gradients for the fit (floating) parameters.
-        grads = np.zeros((len(fitparams), prob.shape[0]), dtype=np.float)
+        grads = np.zeros((len(fitparams), prob.shape[0]), dtype=np.float64)
 
         # Create a dictionary to map the name of the grid parameter to its
         # index.

--- a/skyllh/core/pdfratio.py
+++ b/skyllh/core/pdfratio.py
@@ -189,7 +189,7 @@ class SingleSourcePDFRatioArrayArithmetic(object):
         # initialize the mapping with -1 first in order to be able to check in
         # the end if all fit parameters found a PDF ratio object.
         self._fitparam_idx_2_pdfratio_idx = np.repeat(
-            np.array([-1], dtype=np.int), len(self._fitparam_list))
+            np.array([-1], dtype=np.int64), len(self._fitparam_list))
         for ((fpidx, fitparam), (pridx, pdfratio)) in itertools.product(
                 enumerate(self._fitparam_list), enumerate(self.pdfratio_list)):
             if(fitparam.name in pdfratio.fitparam_names):
@@ -623,7 +623,7 @@ class SigOverBkgPDFRatio(PDFRatio):
         """Returns the list of fit parameter names the signal PDF depends on.
         """
         return self._sig_pdf.param_set.floating_param_name_list
-    
+
     def get_ratio(self, tdm, params=None, tl=None):
         """Calculates the PDF ratio for the given trial events.
 

--- a/skyllh/core/pdfratio.py
+++ b/skyllh/core/pdfratio.py
@@ -269,7 +269,8 @@ class SingleSourcePDFRatioArrayArithmetic(object):
             # Create a (N_pdfratios,N_events)-shaped array to hold the PDF ratio
             # values of each PDF ratio object for each event.
             self._ratio_values = np.empty(
-                (len(self._pdfratio_list), tdm.n_selected_events), dtype=np.float)
+                (len(self._pdfratio_list), tdm.n_selected_events),
+                dtype=np.float64)
 
         self._precompute_static_pdfratio_values(tdm)
 
@@ -698,7 +699,7 @@ class SigOverBkgPDFRatio(PDFRatio):
                 'the get_gradient method!')
 
         # Create the 1D return array for the gradient.
-        grad = np.zeros((tdm.n_selected_events,), dtype=np.float)
+        grad = np.zeros((tdm.n_selected_events,), dtype=np.float64)
 
         # Calculate the gradient for the given fit parameter.
         # There are four cases:

--- a/skyllh/core/signal_generator.py
+++ b/skyllh/core/signal_generator.py
@@ -175,7 +175,7 @@ class SignalGenerator(SignalGeneratorBase):
             ('shg_idx', get_smallest_numpy_int_type((0, n_sources))),
             ('shg_src_idx', get_smallest_numpy_int_type(
                 [0]+[shg.n_sources for shg in shg_list])),
-            ('weight', np.float)
+            ('weight', np.float64)
         ]
         self._sig_candidates = np.empty(
             (0,), dtype=sig_candidates_dtype, order='F')
@@ -255,7 +255,7 @@ class SignalGenerator(SignalGeneratorBase):
         # The mu_fluxes array is the flux of each source for mu mean detected
         # signal events.
         n_sources = self._src_hypo_group_manager.n_sources
-        mu_fluxes = np.empty((n_sources,), dtype=np.float)
+        mu_fluxes = np.empty((n_sources,), dtype=np.float64)
 
         shg_list = self._src_hypo_group_manager.src_hypo_group_list
         mu_fluxes_idx_offset = 0
@@ -408,7 +408,7 @@ class MultiSourceSignalGenerator(SignalGenerator):
             ('shg_idx', get_smallest_numpy_int_type((0, n_sources))),
             ('shg_src_idx', get_smallest_numpy_int_type(
                 [0]+[shg.n_sources for shg in shg_list])),
-            ('weight', np.float)
+            ('weight', np.float64)
         ]
         self._sig_candidates = np.empty(
             (0,), dtype=sig_candidates_dtype, order='F')

--- a/skyllh/core/signalpdf.py
+++ b/skyllh/core/signalpdf.py
@@ -165,7 +165,7 @@ class GaussianPSFPointLikeSourceSignalSpatialPDF(SpatialPDF, IsSignalPDF):
         # If the signal hypothesis contains single source
         # return the output here.
         if(len(get_data('src_array')['ra']) == 1):
-            grads = np.array([], dtype=np.float)
+            grads = np.array([], dtype=np.float64)
             # The new interface returns the pdf only for a single source.
             return (prob[0], grads)
         else:
@@ -346,7 +346,7 @@ class SignalTimePDF(TimePDF, IsSignalPDF):
 
         # The sum of the on-time integrals of the time profile, A, will be zero
         # if the time profile is entirly during detector off-time.
-        prob = np.zeros((tdm.n_selected_events,), dtype=np.float)
+        prob = np.zeros((tdm.n_selected_events,), dtype=np.float64)
         if(self._S > 0):
             prob[on] = self._time_profile.get_value(
                 events_time[on]) / (self._I * self._S)

--- a/skyllh/core/smoothing.py
+++ b/skyllh/core/smoothing.py
@@ -155,7 +155,7 @@ class BlockSmoothingFilter(SmoothingFilter):
         if(nbins <= 0):
             raise ValueError('The nbins argument must be greater zero!')
 
-        arr = np.ones(2*nbins + 1, dtype=np.float)
+        arr = np.ones(2*nbins + 1, dtype=np.float64)
 
         super(BlockSmoothingFilter, self).__init__(arr)
 

--- a/skyllh/core/source_hypothesis.py
+++ b/skyllh/core/source_hypothesis.py
@@ -34,7 +34,7 @@ class SourceHypoGroupManager(object):
         # Define a 2D numpy array of shape (N_sources,2) that maps the source
         # index (0 to N_sources-1) to the index of the group and the source
         # index within the group for fast access.
-        self._sidx_to_gidx_gsidx_map_arr = np.empty((0,2), dtype=np.int)
+        self._sidx_to_gidx_gsidx_map_arr = np.empty((0,2), dtype=np.int64)
 
         # Add source hypo groups if specified.
         if(src_hypo_groups is not None):
@@ -86,7 +86,7 @@ class SourceHypoGroupManager(object):
             The SourceHypoGroup instance for which the map array should get
             extented.
         """
-        arr = np.empty((shg.n_sources,2), dtype=np.int)
+        arr = np.empty((shg.n_sources,2), dtype=np.int64)
         arr[:,0] = self.n_src_hypo_groups-1 # Group index.
         arr[:,1] = np.arange(shg.n_sources) # Group source index.
         self._sidx_to_gidx_gsidx_map_arr = np.vstack(

--- a/skyllh/i3/backgroundpdf.py
+++ b/skyllh/i3/backgroundpdf.py
@@ -153,7 +153,7 @@ class BackgroundI3SpatialPDF(SpatialPDF, UsesBinning, IsBackgroundPDF):
 
         prob = 0.5 / np.pi * np.exp(log_spline_val)
 
-        grads = np.array([], dtype=np.float)
+        grads = np.array([], dtype=np.float64)
 
         return (prob, grads)
 

--- a/skyllh/i3/detsigyield.py
+++ b/skyllh/i3/detsigyield.py
@@ -154,7 +154,7 @@ class PointLikeSourceI3DetSigYieldImplMethod(
         if(not issequenceof(sources, PointLikeSource)):
             raise TypeError('The source argument must be an instance of PointLikeSource!')
 
-        arr = np.empty((len(sources),), dtype=[('dec', np.float)])
+        arr = np.empty((len(sources),), dtype=[('dec', np.float64)])
         for (i, src) in enumerate(sources):
             arr['dec'][i] = src.dec
 
@@ -435,8 +435,8 @@ class PowerLawFluxPointLikeSourceI3DetSigYield(I3DetSigYield):
         src_gamma = src_flux_params['gamma']
 
         # Create results array.
-        values = np.zeros_like(src_dec, dtype=np.float)
-        grads = np.zeros_like(src_dec, dtype=np.float)
+        values = np.zeros_like(src_dec, dtype=np.float64)
+        grads = np.zeros_like(src_dec, dtype=np.float64)
 
         # Calculate the detector signal yield only for the sources for
         # which we actually have detector acceptance. For the other sources,

--- a/skyllh/i3/pdfratio.py
+++ b/skyllh/i3/pdfratio.py
@@ -83,7 +83,7 @@ class I3EnergySigSetOverBkgPDFRatioSpline(SigSetOverBkgPDFRatio, IsParallelizabl
 
             # Create the ratio array with the same shape than the background pdf
             # histogram.
-            ratio = np.ones_like(bkgpdf.hist, dtype=np.float)
+            ratio = np.ones_like(bkgpdf.hist, dtype=np.float64)
 
             # Fill the ratio array.
             ratio = fillmethod.fill_ratios(ratio,

--- a/skyllh/i3/signal_generation.py
+++ b/skyllh/i3/signal_generation.py
@@ -221,7 +221,7 @@ class PointLikeSourceI3SignalGenerationMethod(SignalGenerationMethod):
         n_sources = shg.n_sources
 
         # Get 1D array of source declination.
-        src_dec = np.empty((n_sources,), dtype=np.float)
+        src_dec = np.empty((n_sources,), dtype=np.float64)
         for (k, source) in enumerate(shg.source_list):
             if(not isinstance(source, PointLikeSource)):
                 raise TypeError('The source instance must be an instance of '
@@ -401,7 +401,7 @@ class MultiPointLikeSourceI3SignalGenerationMethod(
         n_sources = shg.n_sources
 
         # Get 1D array of source declination.
-        src_dec = np.empty((n_sources,), dtype=np.float)
+        src_dec = np.empty((n_sources,), dtype=np.float64)
         for (k, source) in enumerate(shg.source_list):
             if(not isinstance(source, PointLikeSource)):
                 raise TypeError(
@@ -439,9 +439,9 @@ class MultiPointLikeSourceI3SignalGenerationMethod(
         for bi in range(n_batches):
             if(bi != n_batches-1):
                 band_mask = np.logical_and(
-                            (data_mc_sin_true_dec >= 
+                            (data_mc_sin_true_dec >=
                                 src_sin_dec_band_min[bi*self.batch_size:(bi+1)*self.batch_size][:, np.newaxis]),
-                            (data_mc_sin_true_dec <= 
+                            (data_mc_sin_true_dec <=
                                 src_sin_dec_band_max[bi*self.batch_size:(bi+1)*self.batch_size][:, np.newaxis])
                             )
                 if(self.energy_range is not None):
@@ -458,9 +458,9 @@ class MultiPointLikeSourceI3SignalGenerationMethod(
             else:
                 n_final_batch = int(n_sources - bi*self.batch_size)
                 band_mask = np.logical_and(
-                            (data_mc_sin_true_dec >= 
+                            (data_mc_sin_true_dec >=
                                 src_sin_dec_band_min[bi*self.batch_size:][:, np.newaxis]),
-                            (data_mc_sin_true_dec <= 
+                            (data_mc_sin_true_dec <=
                                 src_sin_dec_band_max[bi*self.batch_size:][:, np.newaxis])
                             )
                 if(self.energy_range is not None):

--- a/skyllh/i3/utils/sensitivity.py
+++ b/skyllh/i3/utils/sensitivity.py
@@ -64,7 +64,7 @@ def generate_ps_sin_dec_h0_ts_values(
         int((sin_dec_max-sin_dec_min)/sin_dec_step)+1, endpoint=True)
 
     h0_ts_vals_arr = np.empty(
-        (len(sin_dec_arr), n_iter, n_bkg_trials), dtype=np.float)
+        (len(sin_dec_arr), n_iter, n_bkg_trials), dtype=np.float64)
 
     logger.debug(
         'Generating %d null-hypothesis trials for %d sin(dec) values, '

--- a/skyllh/physics/flux_model.py
+++ b/skyllh/physics/flux_model.py
@@ -811,7 +811,7 @@ class BoxTimeFluxProfile(TimeFluxProfile):
             t1 = t1 * time_unit_conv_factor
             t2 = t2 * time_unit_conv_factor
 
-        integral = np.zeros((t1.shape[0],), dtype=np.float)
+        integral = np.zeros((t1.shape[0],), dtype=np.float64)
 
         m = (t2 >= self._t_start) & (t1 <= self._t_end)
         N = np.count_nonzero(m)

--- a/skyllh/physics/source.py
+++ b/skyllh/physics/source.py
@@ -45,7 +45,7 @@ class SourceLocation(object):
 
 class SourceWeights(object):
     """Stores the relative weights of a source, i.e. weights and gradients.
-       There are two weights that should be included. one is the detector weight, 
+       There are two weights that should be included. one is the detector weight,
        which is declination dependent, and the other is a hypothesis weight, and that
        is provided by the user.
     """
@@ -90,11 +90,11 @@ class SourceModel(object):
     """
     def __init__(self, ra, dec, src_w=None, src_w_grad=None, src_w_W=None):
         self.loc = SourceLocation(ra, dec)
-        src_w = np.ones_like(self.loc.ra, dtype=np.float)
-        src_w_grad = np.zeros_like(self.loc.ra, dtype=np.float)
+        src_w = np.ones_like(self.loc.ra, dtype=np.float64)
+        src_w_grad = np.zeros_like(self.loc.ra, dtype=np.float64)
 
         if (src_w_W is None):
-            src_w_W    = np.ones_like(self.loc.ra, dtype=np.float)
+            src_w_W = np.ones_like(self.loc.ra, dtype=np.float64)
 
         self.weight = SourceWeights(src_w, src_w_grad, src_w_W)
 

--- a/skyllh/physics/time_profile.py
+++ b/skyllh/physics/time_profile.py
@@ -245,7 +245,7 @@ class BoxTimeProfile(TimeProfileModel):
         t1 = np.atleast_1d(t1)
         t2 = np.atleast_1d(t2)
 
-        integrals = np.zeros((t1.shape[0],), dtype=np.float)
+        integrals = np.zeros((t1.shape[0],), dtype=np.float64)
 
         m = (t2 > self._t_start) & (t1 < self._t_end)
         N = np.count_nonzero(m)
@@ -288,7 +288,7 @@ class BoxTimeProfile(TimeProfileModel):
         """
         t = np.atleast_1d(t)
 
-        values = np.zeros((t.shape[0],), dtype=np.float)
+        values = np.zeros((t.shape[0],), dtype=np.float64)
         m = (t >= self._t_start) & (t < self._t_end)
         values[m] = 1./self.duration
 

--- a/skyllh/plotting/core/pdfratio.py
+++ b/skyllh/plotting/core/pdfratio.py
@@ -105,7 +105,7 @@ class SpatialSigOverBkgPDFRatioPlotter(object):
         rabins = int(np.ceil(raaxis.length / np.deg2rad(delta_ra_deg)))
         decbins = int(np.ceil(decaxis.length / np.deg2rad(delta_dec_deg)))
 
-        ratios = np.zeros((rabins,decbins), dtype=np.float)
+        ratios = np.zeros((rabins,decbins), dtype=np.float64)
 
         ra_binedges = np.linspace(raaxis.vmin, raaxis.vmax, rabins+1)
         ra_bincenters = 0.5*(ra_binedges[:-1] + ra_binedges[1:])
@@ -117,10 +117,10 @@ class SpatialSigOverBkgPDFRatioPlotter(object):
         events = DataFieldRecordArray(
             np.zeros(
                 (ratios.size,),
-                dtype=[('ira', np.int64), ('ra', np.float),
-                       ('idec', np.int64), ('dec', np.float),
-                       ('sin_dec', np.float),
-                       ('ang_err', np.float)]))
+                dtype=[('ira', np.int64), ('ra', np.float64),
+                       ('idec', np.int64), ('dec', np.float64),
+                       ('sin_dec', np.float64),
+                       ('ang_err', np.float64)]))
         for (i, ((ira,ra),(idec,dec))) in enumerate(itertools.product(
                                                 enumerate(ra_bincenters),
                                                 enumerate(dec_bincenters))):

--- a/skyllh/plotting/core/pdfratio.py
+++ b/skyllh/plotting/core/pdfratio.py
@@ -117,8 +117,9 @@ class SpatialSigOverBkgPDFRatioPlotter(object):
         events = DataFieldRecordArray(
             np.zeros(
                 (ratios.size,),
-                dtype=[('ira', np.int), ('ra', np.float),
-                       ('idec', np.int), ('dec', np.float), ('sin_dec', np.float),
+                dtype=[('ira', np.int64), ('ra', np.float),
+                       ('idec', np.int64), ('dec', np.float),
+                       ('sin_dec', np.float),
                        ('ang_err', np.float)]))
         for (i, ((ira,ra),(idec,dec))) in enumerate(itertools.product(
                                                 enumerate(ra_bincenters),

--- a/skyllh/plotting/core/signalpdf.py
+++ b/skyllh/plotting/core/signalpdf.py
@@ -125,8 +125,8 @@ class SignalSpatialPDFPlotter(object):
 
         # Generate events that fall into the probability bins.
         events = DataFieldRecordArray(np.zeros((probs.size,),
-            dtype=[('ira', np.int), ('ra', np.float),
-                   ('idec', np.int), ('dec', np.float),
+            dtype=[('ira', np.int64), ('ra', np.float),
+                   ('idec', np.int64), ('dec', np.float),
                    ('ang_err', np.float)]))
         for (i, ((ira,ra),(idec,dec))) in enumerate(itertools.product(
                 enumerate(ra_bincenters),

--- a/skyllh/plotting/core/signalpdf.py
+++ b/skyllh/plotting/core/signalpdf.py
@@ -121,13 +121,13 @@ class SignalSpatialPDFPlotter(object):
         dec_binedges = np.linspace(dec_min, dec_max, decbins+1)
         dec_bincenters = 0.5*(dec_binedges[:-1] + dec_binedges[1:])
 
-        probs = np.zeros((rabins,decbins), dtype=np.float)
+        probs = np.zeros((rabins,decbins), dtype=np.float64)
 
         # Generate events that fall into the probability bins.
         events = DataFieldRecordArray(np.zeros((probs.size,),
-            dtype=[('ira', np.int64), ('ra', np.float),
-                   ('idec', np.int64), ('dec', np.float),
-                   ('ang_err', np.float)]))
+            dtype=[('ira', np.int64), ('ra', np.float64),
+                   ('idec', np.int64), ('dec', np.float64),
+                   ('ang_err', np.float64)]))
         for (i, ((ira,ra),(idec,dec))) in enumerate(itertools.product(
                 enumerate(ra_bincenters),
                 enumerate(dec_bincenters))):

--- a/skyllh/plotting/i3/backgroundpdf.py
+++ b/skyllh/plotting/i3/backgroundpdf.py
@@ -87,7 +87,7 @@ class BackgroundI3SpatialPDFPlotter(object):
 
         sin_dec_points = sin_dec_binning.bincenters
         events = DataFieldRecordArray(np.zeros((pdfprobs.size,),
-                          dtype=[('sin_dec', np.float)]))
+                          dtype=[('sin_dec', np.float64)]))
         for (i, sin_dec) in enumerate(sin_dec_points):
             events['sin_dec'][i] = sin_dec
 

--- a/skyllh/plotting/i3/pdf.py
+++ b/skyllh/plotting/i3/pdf.py
@@ -93,8 +93,8 @@ class I3EnergyPDFPlotter(object):
 
         pdf_values = np.zeros((xbinning.nbins, ybinning.nbins), dtype=np.float)
         events = DataFieldRecordArray(np.zeros((pdf_values.size,),
-            dtype=[('ix', np.int), (xbinning.name, np.float),
-                   ('iy', np.int), (ybinning.name, np.float)]))
+            dtype=[('ix', np.int64), (xbinning.name, np.float),
+                   ('iy', np.int64), (ybinning.name, np.float)]))
         for (i, ((ix,x),(iy,y))) in enumerate(itertools.product(
                 enumerate(xbinning.bincenters),
                 enumerate(ybinning.bincenters))):

--- a/skyllh/plotting/i3/pdf.py
+++ b/skyllh/plotting/i3/pdf.py
@@ -91,10 +91,10 @@ class I3EnergyPDFPlotter(object):
         # The I3EnergyPDF object has two axes, one for log10_energy and sin_dec.
         (xbinning, ybinning) = self._pdf.binnings
 
-        pdf_values = np.zeros((xbinning.nbins, ybinning.nbins), dtype=np.float)
+        pdf_values = np.zeros((xbinning.nbins, ybinning.nbins), dtype=np.float64)
         events = DataFieldRecordArray(np.zeros((pdf_values.size,),
-            dtype=[('ix', np.int64), (xbinning.name, np.float),
-                   ('iy', np.int64), (ybinning.name, np.float)]))
+            dtype=[('ix', np.int64), (xbinning.name, np.float64),
+                   ('iy', np.int64), (ybinning.name, np.float64)]))
         for (i, ((ix,x),(iy,y))) in enumerate(itertools.product(
                 enumerate(xbinning.bincenters),
                 enumerate(ybinning.bincenters))):

--- a/skyllh/plotting/i3/pdfratio.py
+++ b/skyllh/plotting/i3/pdfratio.py
@@ -98,10 +98,10 @@ class I3EnergySigSetOverBkgPDFRatioSplinePlotter(object):
 
         # Create a 2D array with the ratio values. We put one event into each
         # bin.
-        ratios = np.zeros((xbinning.nbins, ybinning.nbins), dtype=np.float)
+        ratios = np.zeros((xbinning.nbins, ybinning.nbins), dtype=np.float64)
         events = DataFieldRecordArray(np.zeros((ratios.size,),
-            dtype=[('ix', np.int64), (xbinning.name, np.float),
-                   ('iy', np.int64), (ybinning.name, np.float)]))
+            dtype=[('ix', np.int64), (xbinning.name, np.float64),
+                   ('iy', np.int64), (ybinning.name, np.float64)]))
         for (i, ((ix,x),(iy,y))) in enumerate(itertools.product(
                 enumerate(xbinning.bincenters),
                 enumerate(ybinning.bincenters))):

--- a/skyllh/plotting/i3/pdfratio.py
+++ b/skyllh/plotting/i3/pdfratio.py
@@ -100,8 +100,8 @@ class I3EnergySigSetOverBkgPDFRatioSplinePlotter(object):
         # bin.
         ratios = np.zeros((xbinning.nbins, ybinning.nbins), dtype=np.float)
         events = DataFieldRecordArray(np.zeros((ratios.size,),
-            dtype=[('ix', np.int), (xbinning.name, np.float),
-                   ('iy', np.int), (ybinning.name, np.float)]))
+            dtype=[('ix', np.int64), (xbinning.name, np.float),
+                   ('iy', np.int64), (ybinning.name, np.float)]))
         for (i, ((ix,x),(iy,y))) in enumerate(itertools.product(
                 enumerate(xbinning.bincenters),
                 enumerate(ybinning.bincenters))):

--- a/skyllh/plotting/utils/trials.py
+++ b/skyllh/plotting/utils/trials.py
@@ -120,9 +120,9 @@ def plot_ns_fit_vs_mean_ns_inj(
     hist_weights = np.ones_like(trials[mean_n_sig_key])
     (mean_n_sig, n_trials) = np.unique(
         trials[mean_n_sig_key], return_counts=True)
-    ns_fit_median = np.empty_like(mean_n_sig, dtype=np.float)
-    ns_fit_uq = np.empty_like(mean_n_sig, dtype=np.float)
-    ns_fit_lq = np.empty_like(mean_n_sig, dtype=np.float)
+    ns_fit_median = np.empty_like(mean_n_sig, dtype=np.float64)
+    ns_fit_uq = np.empty_like(mean_n_sig, dtype=np.float64)
+    ns_fit_lq = np.empty_like(mean_n_sig, dtype=np.float64)
     for (idx, (mean_n_sig_,n_trials_)) in enumerate(zip(mean_n_sig, n_trials)):
         m = trials[mean_n_sig_key] == mean_n_sig_
         hist_weights[m] /= n_trials_
@@ -329,9 +329,9 @@ def plot_gamma_fit_vs_mean_ns_inj(
     hist_weights = np.ones_like(trials[mean_n_sig_key])
     (mean_n_sig, n_trials) = np.unique(
         trials[mean_n_sig_key], return_counts=True)
-    gamma_fit_median = np.empty_like(mean_n_sig, dtype=np.float)
-    gamma_fit_uq = np.empty_like(mean_n_sig, dtype=np.float)
-    gamma_fit_lq = np.empty_like(mean_n_sig, dtype=np.float)
+    gamma_fit_median = np.empty_like(mean_n_sig, dtype=np.float64)
+    gamma_fit_uq = np.empty_like(mean_n_sig, dtype=np.float64)
+    gamma_fit_lq = np.empty_like(mean_n_sig, dtype=np.float64)
     for (idx, (mean_n_sig_,n_trials_)) in enumerate(zip(mean_n_sig, n_trials)):
         m = trials[mean_n_sig_key] == mean_n_sig_
         hist_weights[m] /= n_trials_

--- a/tests/core/test_storage.py
+++ b/tests/core/test_storage.py
@@ -9,9 +9,9 @@ from skyllh.core.storage import DataFieldRecordArray
 
 class DataFieldRecordArray_TestCase(unittest.TestCase):
     def setUp(self):
-        self.field1 = np.array([1.4, 1.3, 1.5, 1.1, 1.2], dtype=np.float)
-        self.field2 = np.array([2.5, 2.1, 2.3, 2.4, 2.2], dtype=np.float)
-        self.field3 = np.array([3.2, 3.5, 3.1, 3.3, 3.4], dtype=np.float)
+        self.field1 = np.array([1.4, 1.3, 1.5, 1.1, 1.2], dtype=np.float64)
+        self.field2 = np.array([2.5, 2.1, 2.3, 2.4, 2.2], dtype=np.float64)
+        self.field3 = np.array([3.2, 3.5, 3.1, 3.3, 3.4], dtype=np.float64)
         data = dict(
             field1 = self.field1,
             field2 = self.field2,
@@ -53,11 +53,11 @@ class DataFieldRecordArray_TestCase(unittest.TestCase):
     def test__setitem__(self):
         # Set an entire field with data of not the same length.
         with self.assertRaises(ValueError):
-            new_field2 = np.array([2.51, 2.12, 2.33, 2.44], dtype=np.float)
+            new_field2 = np.array([2.51, 2.12, 2.33, 2.44], dtype=np.float64)
             self.arr['field2'] = new_field2
 
         # Set an entire field with new values.
-        new_field2 = np.array([2.51, 2.12, 2.33, 2.44, 2.25], dtype=np.float)
+        new_field2 = np.array([2.51, 2.12, 2.33, 2.44, 2.25], dtype=np.float64)
         self.arr['field2'] = new_field2
         assert_array_almost_equal(self.arr['field2'], new_field2)
 
@@ -76,7 +76,7 @@ class DataFieldRecordArray_TestCase(unittest.TestCase):
         assert_array_almost_equal(self.arr['field1'], self.field1)
         assert_array_almost_equal(
             self.arr['field2'],
-            np.array([2.5, 2.12, 2.33, 2.4, 2.25], dtype=np.float))
+            np.array([2.5, 2.12, 2.33, 2.4, 2.25], dtype=np.float64))
         assert_array_almost_equal(self.arr['field3'], self.field3)
 
         # Reset the array.
@@ -94,14 +94,14 @@ class DataFieldRecordArray_TestCase(unittest.TestCase):
         assert_array_almost_equal(self.arr['field1'], self.field1)
         assert_array_almost_equal(
             self.arr['field2'],
-            np.array([2.51, 2.12, 2.3, 2.44, 2.2], dtype=np.float))
+            np.array([2.51, 2.12, 2.3, 2.44, 2.2], dtype=np.float64))
         assert_array_almost_equal(self.arr['field3'], self.field3)
 
         # Reset the array.
         self.setUp()
 
         # Add a new field.
-        new_field = np.array([4.2, 4.5, 4.1, 4.3, 4.4], dtype=np.float)
+        new_field = np.array([4.2, 4.5, 4.1, 4.3, 4.4], dtype=np.float64)
         self.arr['field4'] = new_field
         self.assertTrue('field4' in self.arr)
         self.assertTrue('field4' in self.arr.field_name_list)
@@ -144,13 +144,13 @@ class DataFieldRecordArray_TestCase(unittest.TestCase):
         self.arr.sort_by_field('field2')
         assert_array_almost_equal(
             self.arr['field1'],
-            np.array([1.3, 1.2, 1.5, 1.1, 1.4], dtype=np.float))
+            np.array([1.3, 1.2, 1.5, 1.1, 1.4], dtype=np.float64))
         assert_array_almost_equal(
             self.arr['field2'],
-            np.array([2.1, 2.2, 2.3, 2.4, 2.5], dtype=np.float))
+            np.array([2.1, 2.2, 2.3, 2.4, 2.5], dtype=np.float64))
         assert_array_almost_equal(
             self.arr['field3'],
-            np.array([3.5, 3.4, 3.1, 3.3, 3.2], dtype=np.float))
+            np.array([3.5, 3.4, 3.1, 3.3, 3.2], dtype=np.float64))
 
     def test_tidy_up(self):
         self.arr.tidy_up('field2')


### PR DESCRIPTION
Replaced deprecated numpy data types:
 ``numpy.bool`` to ``numpy.bool_``,
 ``numpy.int`` to ``numpy.int64``,
 ``numpy.float`` to ``numpy.float64``,
 ``numpy.object`` to ``numpy.object_``.