### PR TITLE
Update `h0_ts_quantile` default for 5sigma dp

### DIFF
--- a/skyllh/core/analysis_utils.py
+++ b/skyllh/core/analysis_utils.py
@@ -855,7 +855,7 @@ def estimate_sensitivity(
 
 
 def estimate_discovery_potential(
-        ana, rss, h0_trials=None, h0_ts_quantile=5.733e-7, p=0.5, eps_p=0.005,
+        ana, rss, h0_trials=None, h0_ts_quantile=2.8665e-7, p=0.5, eps_p=0.005,
         mu_range=None, min_dmu=0.5, bkg_kwargs=None, sig_kwargs=None,
         ppbar=None, tl=None, pathfilename=None):
     """Estimates the mean number of signal events that whould have to be
@@ -865,7 +865,7 @@ def estimate_discovery_potential(
     null hypothesis test-statistic values are larger than c.
 
     For the 5 sigma discovery potential `h0_ts_quantile`, and `p` are usually
-    set to 5.733e-7, and 0.5, respectively.
+    set to 2.8665e-7, and 0.5, respectively.
 
     Parameters
     ----------


### PR DESCRIPTION
We used the updated value when computing trials for science paper[1], and @HansN87 also thinks that this should be the definition for 5sigma discovery potential. People would no longer need to overwrite it with e.g.:
```
>>> 1 - norm.cdf(5)
2.866515719235352e-07
```


[1]
https://github.com/icecube/wg-nu-sources/blob/da6be6b9375f662cb1002f05c0a1d86ed7bb6831/2020_northern_tracks_pass2_timeintegrated_ps/analysis_scripts/ps_performance.py#L31-L35