### PR TITLE
Fix missing jQuery

### DIFF
--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -50,7 +50,8 @@ extensions = [
     'sphinx.ext.intersphinx',
     'nbsphinx',
     'sphinxcontrib.apidoc',
-    'sphinx_multiversion'
+    'sphinx_multiversion',
+    'sphinx_rtd_theme'
 ]
 
 # Extensions configuration.


### PR DESCRIPTION
Sphinx RTD theme has to be set in extensions to fix including jQuery for the new sphinx 6 versions:
https://sphinx-rtd-theme.readthedocs.io/en/stable/changelog.html#known-issues

Fixes search and documentation version choice functionality