### PR TITLE
Move `get_tdm_field_func_psi` to core

### DIFF
--- a/skyllh/analyses/i3/publicdata_ps/mcbkg_ps.py
+++ b/skyllh/analyses/i3/publicdata_ps/mcbkg_ps.py
@@ -28,7 +28,6 @@ from skyllh.analyses.i3.publicdata_ps.signalpdf import (
 )
 from skyllh.analyses.i3.publicdata_ps.utils import (
     create_energy_cut_spline,
-    get_tdm_field_func_psi,
 )
 from skyllh.core.analysis import (
     SingleSourceMultiDatasetLLHRatioAnalysis as Analysis,
@@ -100,6 +99,9 @@ from skyllh.core.trialdata import (
 )
 from skyllh.core.utils.analysis import (
     pointlikesource_to_data_field_array,
+)
+from skyllh.core.utils.tdm import (
+    get_tdm_field_func_psi,
 )
 from skyllh.datasets.i3 import (
     data_samples,

--- a/skyllh/analyses/i3/publicdata_ps/time_dependent_ps.py
+++ b/skyllh/analyses/i3/publicdata_ps/time_dependent_ps.py
@@ -24,7 +24,6 @@ from skyllh.analyses.i3.publicdata_ps.signalpdf import (
 from skyllh.analyses.i3.publicdata_ps.utils import (
     clip_grl_start_times,
     create_energy_cut_spline,
-    get_tdm_field_func_psi,
 )
 
 from skyllh.core.analysis import (
@@ -113,6 +112,9 @@ from skyllh.core.trialdata import (
 from skyllh.core.utils.analysis import (
     create_trial_data_file,
     pointlikesource_to_data_field_array,
+)
+from skyllh.core.utils.tdm import (
+    get_tdm_field_func_psi,
 )
 
 from skyllh.datasets.i3 import (

--- a/skyllh/analyses/i3/publicdata_ps/time_integrated_ps.py
+++ b/skyllh/analyses/i3/publicdata_ps/time_integrated_ps.py
@@ -24,7 +24,6 @@ from skyllh.analyses.i3.publicdata_ps.signalpdf import (
 )
 from skyllh.analyses.i3.publicdata_ps.utils import (
     create_energy_cut_spline,
-    get_tdm_field_func_psi,
 )
 
 from skyllh.core.analysis import (
@@ -101,6 +100,9 @@ from skyllh.core.trialdata import (
 from skyllh.core.utils.analysis import (
     create_trial_data_file,
     pointlikesource_to_data_field_array,
+)
+from skyllh.core.utils.tdm import (
+    get_tdm_field_func_psi,
 )
 
 from skyllh.datasets.i3 import (

--- a/skyllh/analyses/i3/publicdata_ps/utils.py
+++ b/skyllh/analyses/i3/publicdata_ps/utils.py
@@ -10,9 +10,6 @@ from scipy import (
 from skyllh.core.binning import (
     get_bincenters_from_binedges,
 )
-from skyllh.core.utils.coords import (
-    angular_separation,
-)
 
 
 class FctSpline1D(object):
@@ -310,47 +307,3 @@ def create_energy_cut_spline(
         sindec_centers, min_log_e, k=2, s=spl_smooth)
 
     return spline
-
-
-def get_tdm_field_func_psi(psi_floor=None):
-    """Returns the TrialDataManager (TDM) field function for psi with an
-    optional psi value floor.
-
-    Parameters
-    ----------
-    psi_floor : float | None
-        The optional floor value for psi. This should be ``None`` for a standard
-        point-source analysis that uses an analytic function for the detector's
-        point-spread-function (PSF).
-
-    Returns
-    -------
-    tdm_field_func_psi : function
-        TrialDataManager (TDM) field function for psi.
-    """
-    def tdm_field_func_psi(
-            tdm,
-            shg_mgr,
-            pmm):
-        """TDM data field function to calculate the opening angle between the
-        source positions and the event's reconstructed position.
-        """
-        (src_idxs, evt_idxs) = tdm.src_evt_idxs
-
-        ra = np.take(tdm.get_data('ra'), evt_idxs)
-        dec = np.take(tdm.get_data('dec'), evt_idxs)
-
-        src_array = tdm.get_data('src_array')
-        src_ra = np.take(src_array['ra'], src_idxs)
-        src_dec = np.take(src_array['dec'], src_idxs)
-
-        psi = angular_separation(
-            ra1=ra,
-            dec1=dec,
-            ra2=src_ra,
-            dec2=src_dec,
-            psi_floor=psi_floor)
-
-        return psi
-
-    return tdm_field_func_psi

--- a/skyllh/core/utils/tdm.py
+++ b/skyllh/core/utils/tdm.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+
+import numpy as np
+
+from skyllh.core.utils.coords import (
+    angular_separation,
+)
+
+
+def get_tdm_field_func_psi(psi_floor=None):
+    """Returns the TrialDataManager (TDM) field function for psi with an
+    optional psi value floor.
+
+    Parameters
+    ----------
+    psi_floor : float | None
+        The optional floor value for psi. This should be ``None`` for a standard
+        point-source analysis that uses an analytic function for the detector's
+        point-spread-function (PSF).
+
+    Returns
+    -------
+    tdm_field_func_psi : function
+        TrialDataManager (TDM) field function for psi.
+    """
+    def tdm_field_func_psi(
+            tdm,
+            shg_mgr,
+            pmm):
+        """TDM data field function to calculate the opening angle between the
+        source positions and the event's reconstructed position.
+        """
+        (src_idxs, evt_idxs) = tdm.src_evt_idxs
+
+        ra = np.take(tdm.get_data('ra'), evt_idxs)
+        dec = np.take(tdm.get_data('dec'), evt_idxs)
+
+        src_array = tdm.get_data('src_array')
+        src_ra = np.take(src_array['ra'], src_idxs)
+        src_dec = np.take(src_array['dec'], src_idxs)
+
+        psi = angular_separation(
+            ra1=ra,
+            dec1=dec,
+            ra2=src_ra,
+            dec2=src_dec,
+            psi_floor=psi_floor)
+
+        return psi
+
+    return tdm_field_func_psi


### PR DESCRIPTION
This change allows to reuse `get_tdm_field_func_psi` function in KDE analyses.