### PR TITLE
Fall back to `evaluate_simple` in case the `search_centers` call fails.

### DIFF
--- a/skyllh/core/signalpdf.py
+++ b/skyllh/core/signalpdf.py
@@ -833,11 +833,15 @@ class SignalMultiDimGridPDFSet(
                     tl,
                     'Get and set basis function indices for all PDFs.'):
                 V = self._cache_eventdata.shape[0]
-                bfi = pdf.pdf.search_centers(
-                    [self._cache_eventdata[i] for i in range(0, V)]
-                )
-                for (_, pdf) in self.items():
-                    pdf.basis_function_indices = bfi
+                try:
+                    bfi = pdf.pdf.search_centers(
+                        [self._cache_eventdata[i] for i in range(0, V)]
+                    )
+                    for (_, pdf) in self.items():
+                        pdf.basis_function_indices = bfi
+                except ValueError:
+                    logger = get_logger(f'{__name__}.{classname(self)}.initialize_for_new_trial')
+                    logger.info("Falling back to the slower photospline evaluation.")
 
     def get_pd(
             self,
@@ -1054,11 +1058,15 @@ class SignalSHGMappedMultiDimGridPDFSet(
                     tl,
                     'Get and set basis function indices for all PDFs.'):
                 V = self._cache_eventdata.shape[0]
-                bfi = pdf.pdf.search_centers(
-                    [self._cache_eventdata[i] for i in range(0, V)]
-                )
-                for (_, pdf) in self.items():
-                    pdf.basis_function_indices = bfi
+                try:
+                    bfi = pdf.pdf.search_centers(
+                        [self._cache_eventdata[i] for i in range(0, V)]
+                    )
+                    for (_, pdf) in self.items():
+                        pdf.basis_function_indices = bfi
+                except ValueError:
+                    logger = get_logger(f'{__name__}.{classname(self)}.initialize_for_new_trial')
+                    logger.info("Falling back to the slower photospline evaluation.")
 
     def get_pd(
             self,

--- a/skyllh/core/signalpdf.py
+++ b/skyllh/core/signalpdf.py
@@ -1120,7 +1120,7 @@ class SignalSHGMappedMultiDimGridPDFSet(
             pdf_key = self.make_key({'shg_idxs': shg_idxs})
             pdf = self.get_pdf(pdf_key)
 
-            with TaskTimer(tl, f'Get PD values for PDF of SHG {shg_idx}.'):
+            with TaskTimer(tl, f'Get PD values for PDF of SHG {shg_idxs}.'):
                 pd_pdf = pdf.get_pd_with_eventdata(
                     tdm=tdm,
                     params_recarray=params_recarray,


### PR DESCRIPTION
In case the photospline `search_centers` call fails (when `eventdata` is outside photospline boundaries) we can fall back to the slower photospline evaluation (`evaluate_simple`) which handles this case by returning 0 for the event.

It is relevant for the northern tracks `v005p00` and `v005p01` datasets.