### PR TITLE
Prefer 'livetime' field from GRL for the total livetime calculation.

### DIFF
--- a/skyllh/i3/dataset.py
+++ b/skyllh/i3/dataset.py
@@ -355,15 +355,22 @@ class I3Dataset(
         # Set the livetime of the dataset from the GRL data when no livetime
         # was specified previously.
         if data.livetime is None and data.grl is not None:
-            if 'start' not in data.grl:
-                raise KeyError(
-                    f'The GRL data for dataset "{self.name}" has no data '
-                    'field named "start"!')
-            if 'stop' not in data.grl:
-                raise KeyError(
-                    f'The GRL data for dataset "{self.name}" has no data '
-                    'field named "stop"!')
-            data.livetime = np.sum(data.grl['stop'] - data.grl['start'])
+            if 'livetime' in data.grl:
+                # The `livetime` column accounts for livetime gaps within run,
+                # therefore it is more precise than `stop` - `start`.
+                data.livetime = np.sum(data.grl['livetime'])
+            else:
+                # If `livetime` field does not exist fall back to
+                # `stop` - `start` implementation.
+                if 'start' not in data.grl:
+                    raise KeyError(
+                        f'The GRL data for dataset "{self.name}" has no data '
+                        'field named "start"!')
+                if 'stop' not in data.grl:
+                    raise KeyError(
+                        f'The GRL data for dataset "{self.name}" has no data '
+                        'field named "stop"!')
+                data.livetime = np.sum(data.grl['stop'] - data.grl['start'])
 
         # Execute all the data preparation functions for this dataset.
         super().prepare_data(


### PR DESCRIPTION
In case the 'livetime' field exists in GRL definition, use it to calculate the total livetime. Fall back to 'stop' - 'start' calculation in case it does not exist.

This makes the GRL handling identical to csky: https://github.com/icecube/csky/blob/7bc9169f9df868c4ef8105bc51820c85986f8cec/csky/selections.py#L261-L267

For datasets with 'length' field we define renaming dictionary
```
dsc.set_dataset_prop('grl_field_name_renaming_dict', {
    'length': 'livetime'
})
```
in the dataset definition.