### PR TITLE
Fix 219

### DIFF
--- a/skyllh/core/signal_generator.py
+++ b/skyllh/core/signal_generator.py
@@ -699,7 +699,8 @@ class MCMultiDatasetSignalGenerator(
             )
             m = (events_meta['ds_idx'] == ds_idx) &\
                 (events_meta['shg_idx'] == shg_idx)
-            events = mc[events_meta['ev_idx'][m]]
+            events_meta = events_meta[m]
+            events = mc[events_meta['ev_idx']]
             if len(events) > 0:
                 events = shg.sig_gen_method.\
                     signal_event_post_sampling_processing(


### PR DESCRIPTION
Apply mask to `events_meta` as we initially draw events from all datasets and `signal_event_post_sampling_processing` expects the same shape of `events_meta` and `events` arrays.

Fixes #219 issue. It does not change the signal injection behaviour when events fall within `valid event field ranges` (e.g. declination range after events rotation). Trials would fail when generating signal for analyses with multi datasets and/or multi source hypothesis groups.

It follows the same logic as in the initial signal events drawing in L886-897:
https://github.com/icecube/skyllh/blob/f8e4ea6eda5987c0df2445259982e937155e0490/skyllh/core/signal_generator.py#L886-L897