### PR TITLE
Fix #223

### DIFF
--- a/skyllh/analyses/i3/publicdata_ps/signal_generator.py
+++ b/skyllh/analyses/i3/publicdata_ps/signal_generator.py
@@ -509,7 +509,7 @@ class PDDatasetSignalGenerator(
                 float_cast(
                     mean,
                     'The `mean` argument must be castable to type of float!'))
-            
+
         n_events = int_cast(
             mean,
             'The `mean` argument must be castable to type of int!')

--- a/skyllh/analyses/i3/publicdata_ps/signal_generator.py
+++ b/skyllh/analyses/i3/publicdata_ps/signal_generator.py
@@ -505,11 +505,11 @@ class PDDatasetSignalGenerator(
             dataset index for which the signal events have been generated.
         """
         if poisson:
-            n_events = rss.random.poisson(
+            mean = rss.random.poisson(
                 float_cast(
                     mean,
                     'The `mean` argument must be castable to type of float!'))
-
+            
         n_events = int_cast(
             mean,
             'The `mean` argument must be castable to type of int!')


### PR DESCRIPTION
The proposed fix was implemented. Another possible solution, as poited by Chiara, would be just to add an else statement.
```
if poisson: 
     mean = rss.random.poisson( 
         float_cast( 
             mean, 
             'The  'mean' argument must be castable to type of float!')) 

else: 
    n_events = int_cast( 
         mean, 
         'The 'mean' argument must be castable to type of int!') 
```
I choose the first solution for consistency with the one already implemented in the analog class MCMultiDatasetSignalGenerator.