### PR TITLE
Fix m_nonzero_bkg definition to avoid overflows.

### DIFF
--- a/skyllh/analyses/i3/publicdata_ps/pdfratio.py
+++ b/skyllh/analyses/i3/publicdata_ps/pdfratio.py
@@ -213,7 +213,7 @@ class PDSigSetOverBkgPDFRatio(
         (bkg_pd,) = tdm.broadcast_selected_events_arrays_to_values_arrays(
             (bkg_pd,))
 
-        m_nonzero_bkg = bkg_pd > 0
+        m_nonzero_bkg = bkg_pd > np.finfo(np.double).resolution
         m_zero_bkg = np.invert(m_nonzero_bkg)
         if np.any(m_zero_bkg):
             ev_idxs = np.where(m_zero_bkg)[0]


### PR DESCRIPTION
Implemented the proposed solution in issue 230.

As a side effect, it will also softer (but not eliminate) the anomalous high TS values for injections where there was no
events in the background and kde smoothing was used. The reason is that now the bkg energy pdf is effectively capped to `numpy.finfo(np.double).resolution` (=1e-15).

This still gives much more margin than the cap_ratio option, which effectively imposes much more restrictive values.

This solution just extends the already solution for the actual zero values when no cap_ratio is present.

https://github.com/icecube/skyllh/blob/6704ef9e796d978e2315425721101badb0e2a0c2/skyllh/analyses/i3/publicdata_ps/pdfratio.py#L230-L237