### PR TITLE
Use only package level loggers

### DIFF
--- a/skyllh/core/debugging.py
+++ b/skyllh/core/debugging.py
@@ -5,10 +5,6 @@ import os.path
 import sys
 
 
-# Initialize the root logger.
-logging.root.setLevel(logging.NOTSET)
-
-
 def get_logger(
         name):
     """Retrieves the logger with the given name from the Python logging system.

--- a/skyllh/scripting/logging.py
+++ b/skyllh/scripting/logging.py
@@ -8,6 +8,7 @@ import logging
 
 from skyllh.core.debugging import (
     get_logger,
+    setup_logger,
     setup_console_handler,
     setup_file_handler,
 )
@@ -19,9 +20,9 @@ def setup_logging(
         log_format=None,
         log_level=logging.INFO,
         debug_pathfilename=None):
-    """Installs console handlers for the ``skyllh`` and ``script_logger_name``
-    loggers. If a debug file is specified, file handlers for debug messages
-    will be installed as well.
+    """Initializes loggers and installs console handlers for the ``skyllh`` and
+    ``script_logger_name`` loggers. If a debug file is specified, file handlers
+    for debug messages will be installed as well.
 
     Parameters
     ----------
@@ -45,6 +46,9 @@ def setup_logging(
     """
     if log_format is None:
         log_format = cfg['debugging']['log_format']
+
+    setup_logger('skyllh', log_level)
+    setup_logger(script_logger_name, log_level)
 
     setup_console_handler(
         cfg=cfg,


### PR DESCRIPTION
Instead of setting `logging.root` use the existing `setup_logging` functionality to set skyllh loggers and handlers at the same logging level. Fixes #236.