### PR TITLE
Keep `time` float64 to avoid cutting events as if they are outside GRL

### DIFF
--- a/skyllh/analyses/i3/publicdata_ps/time_dependent_ps.py
+++ b/skyllh/analyses/i3/publicdata_ps/time_dependent_ps.py
@@ -907,7 +907,7 @@ def create_analysis(  # noqa: C901
     dtc_except_fields = None
     if compress_data is True:
         dtc_dict = {np.dtype(np.float64): np.dtype(np.float32)}
-        dtc_except_fields = ['mcweight']
+        dtc_except_fields = ['mcweight', 'time']
 
     # Define the flux model.
     fluxmodel = SteadyPointlikeFFM(

--- a/skyllh/analyses/i3/publicdata_ps/time_integrated_ps.py
+++ b/skyllh/analyses/i3/publicdata_ps/time_integrated_ps.py
@@ -266,7 +266,7 @@ def create_analysis(
     dtc_except_fields = None
     if compress_data is True:
         dtc_dict = {np.dtype(np.float64): np.dtype(np.float32)}
-        dtc_except_fields = ['mcweight']
+        dtc_except_fields = ['mcweight', 'time']
 
     # Define the flux model.
     fluxmodel = SteadyPointlikeFFM(

--- a/skyllh/analyses/i3/publicdata_ps/time_integrated_ps_function_energy_spectrum.py
+++ b/skyllh/analyses/i3/publicdata_ps/time_integrated_ps_function_energy_spectrum.py
@@ -334,7 +334,7 @@ def create_analysis(
     dtc_except_fields = None
     if compress_data is True:
         dtc_dict = {np.dtype(np.float64): np.dtype(np.float32)}
-        dtc_except_fields = ['mcweight']
+        dtc_except_fields = ['mcweight', 'time']
 
     # Define the flux model.
 


### PR DESCRIPTION
Numpy 2.0 introduced stricter casting rules for floats. If `compress_data` option is set to True, the `time` field was being compressed to float32 and then compared to float64 numbers from GRL. It leads to failing tests, as some event times fall outside GRL start/stop times.

Current analyses should not be affected, as cvmfs has only numpy<2.0 versions available, and publicdata_ps analyses have default option set to False.