### PR TITLE
Vectorize `_renorm_per_y_pairs` method

### DIFF
--- a/skyllh/analyses/i3/publicdata_ps/pdfratio.py
+++ b/skyllh/analyses/i3/publicdata_ps/pdfratio.py
@@ -162,6 +162,7 @@ class PDSigSetOverBkgPDFRatio(SigSetOverBkgPDFRatio):
         (ratio, grads) = self._interpolmethod(tdm=tdm, eventdata=None, params_recarray=src_params_recarray)
 
         # Cache the ratio and gradient values.
+        self._cache_tdm_trial_data_state_id = tdm.trial_data_state_id
         self._cache_fitparams_hash = fitparams_hash
         self._cache_ratio = ratio
         self._cache_grads = grads

--- a/skyllh/analyses/i3/publicdata_ps/utils.py
+++ b/skyllh/analyses/i3/publicdata_ps/utils.py
@@ -129,9 +129,12 @@ class FctSpline2D:
         self._qx = 0.5 * (self.x_max - self.x_min) * gx + 0.5 * (self.x_max + self.x_min)
         self._qw = 0.5 * (self.x_max - self.x_min) * gw
 
+    _LOG10 = np.log(10.0)
+
     @staticmethod
     def _pow10(arr):
-        return np.power(10.0, arr)
+        # Alternative optimized version of np.power(10, arr), ~3x faster.
+        return np.exp(arr * FctSpline2D._LOG10)
 
     def _mask_oor_axes(self, x, y):
         m_x = (x < self.x_min) | (x > self.x_max)

--- a/skyllh/analyses/i3/publicdata_ps/utils.py
+++ b/skyllh/analyses/i3/publicdata_ps/utils.py
@@ -134,7 +134,7 @@ class FctSpline2D:
     @staticmethod
     def _pow10(arr):
         # Alternative optimized version of np.power(10, arr), ~3x faster.
-        return np.exp(arr * FctSpline2D._LOG10)
+        return np.exp(FctSpline2D._LOG10 * arr)
 
     def _mask_oor_axes(self, x, y):
         m_x = (x < self.x_min) | (x > self.x_max)

--- a/skyllh/analyses/i3/publicdata_ps/utils.py
+++ b/skyllh/analyses/i3/publicdata_ps/utils.py
@@ -179,14 +179,13 @@ class FctSpline2D:
 
     def _renorm_per_y_pairs(self, x, y, f):
         """Renormalize paired evaluations so each value is divided by Z(y_i)."""
-        # Compute Z for each distinct y present (no sorting needed for outputs;
-        # np.unique returns a sorted list, but we map back via 'inv').
+        # np.unique returns sorted unique values, which satisfies the ordering
+        # requirement of RectBivariateSpline for grid=True evaluation.
+        # A single batched grid=True call replaces the previous per-y loop,
+        # reducing O(n_unique_y) spline calls to one.
         uniq_y, inv = np.unique(y, return_inverse=True)
-        Z = np.empty_like(uniq_y, dtype=float)
-        for k, yk in enumerate(uniq_y):
-            yq = np.full(self._qx.shape, yk, dtype=float)
-            vals = self._pow10(self.spl_log10_f(self._qx, yq, grid=False))  # (nq,)
-            Z[k] = np.dot(vals, self._qw)
+        vals = self._pow10(self.spl_log10_f(self._qx, uniq_y, grid=True))  # (nq, n_uniq_y)
+        Z = vals.T @ self._qw  # (n_uniq_y,)
         Z[Z == 0] = np.nan
         f /= Z[inv]
         return f


### PR DESCRIPTION
Vectorization results in 3x speed improvement for trials generation (tested with 10yr data release). Analysis tests added in https://github.com/icecube/skyllh/pull/253 passed so I think it should be a safe change

| configuration | without optimization | with optimization | speedup | throughput (without) | throughput (with) |
|---|---|---|---|---|---|
| **single-core (ncpu=1), n=100 trials** ||||||
| wall time (mean) | 24.6 s | 7.41 s | **3.32×** | 4.07 it/s | 13.75 it/s |
|||||||
| **multi-core (ncpu=4), n=100 trials** ||||||
| wall time (mean) | 6.67 s | 2.17 s | **3.07×** | 15.15 it/s | 45.82 it/s |