### PR TITLE
Add back support for fitparam_values arg in public data analysis flux conversion

### DIFF
--- a/skyllh/core/analysis.py
+++ b/skyllh/core/analysis.py
@@ -1770,9 +1770,10 @@ class SingleSourceMultiDatasetLLHRatioAnalysis(LLHRatioAnalysis):
 
         if fitparam_values is not None and self._has_explicit_energy_range_cut():
             raise NotImplementedError(
-                'The calculate_fluxmodel_scaling_factor does not support fitparam_values when an energy_range '
-                'is configured on the analysis. The energy range correction factors are precomputed at the '
-                'reference flux model parameters and are not updated for arbitrary fitparam_values.'
+                'The calculate_fluxmodel_scaling_factor does not support fitparam_values when an explicit '
+                'energy_range is configured either on the analysis or on a signal-generation component. '
+                'The energy range correction factors are precomputed at the reference flux model parameters '
+                'and are not updated for arbitrary fitparam_values.'
             )
 
         src_params_recarray = None

--- a/skyllh/core/analysis.py
+++ b/skyllh/core/analysis.py
@@ -1713,7 +1713,7 @@ class SingleSourceMultiDatasetLLHRatioAnalysis(LLHRatioAnalysis):
 
         self.change_shg_mgr(shg_mgr=self._shg_mgr, update_detsigyield_service=update_detsigyield_service)
 
-    def calculate_fluxmodel_scaling_factor(self, per_source=False):
+    def calculate_fluxmodel_scaling_factor(self, fitparam_values=None, per_source=False):
         """Calculates the factor the source's fluxmodel has to be scaled in order to obtain one signal event in the
         detector.
 
@@ -1730,6 +1730,12 @@ class SingleSourceMultiDatasetLLHRatioAnalysis(LLHRatioAnalysis):
 
         Parameters
         ----------
+        fitparam_values : numpy ndarray | None
+            The (N_fitparam,)-shaped 1D ndarray holding the values of the global floating fit parameters at
+            which the scaling factor should be evaluated. The order must match the order in which parameters
+            were defined in the parameter model mapper.
+            If ``None``, the scaling factor is evaluated at the reference parameter values defined in the
+            flux model.
         per_source : bool
             Whether to return the scaling factor for each source separately. Default is False.
 
@@ -1746,15 +1752,33 @@ class SingleSourceMultiDatasetLLHRatioAnalysis(LLHRatioAnalysis):
                 'The configured signal generator does not implement the fluxmodel_scaling_factor interface!'
             )
 
-        return self._sig_generator.fluxmodel_scaling_factor(per_source=per_source)
+        if fitparam_values is not None and self.sig_gen_energy_range is not None:
+            raise NotImplementedError(
+                'The calculate_fluxmodel_scaling_factor does not support fitparam_values when an energy_range '
+                'is configured on the analysis. The energy range correction factors are precomputed at the '
+                'reference flux model parameters and are not updated for arbitrary fitparam_values.'
+            )
 
-    def mu2flux(self, mu, per_source=False):
+        src_params_recarray = None
+        if fitparam_values is not None:
+            src_params_recarray = self._pmm.create_src_params_recarray(gflp_values=fitparam_values)
+
+        return self._sig_generator.fluxmodel_scaling_factor(
+            per_source=per_source,
+            src_params_recarray=src_params_recarray,
+        )
+
+    def mu2flux(self, mu, fitparam_values=None, per_source=False):
         """Converts the given number of signal events in the detector to the corresponding flux model normalization.
 
         Parameters
         ----------
         mu : float
             The number of signal events in the detector to convert.
+        fitparam_values : numpy ndarray | None
+            The (N_fitparam,)-shaped 1D ndarray holding the values of the global floating fit parameters at
+            which the scaling factor should be evaluated. If ``None``, the reference flux model parameter
+            values are used.
         per_source : bool
             Whether to return the flux normalization for each source separately. Default is False.
 
@@ -1763,15 +1787,19 @@ class SingleSourceMultiDatasetLLHRatioAnalysis(LLHRatioAnalysis):
         float | (n_sources,)-shaped numpy ndarray
             The corresponding flux model normalization(s) for the given number of signal events in the detector.
         """
-        return self.calculate_fluxmodel_scaling_factor(per_source=per_source) * mu
+        return self.calculate_fluxmodel_scaling_factor(fitparam_values=fitparam_values, per_source=per_source) * mu
 
-    def flux2mu(self, flux_norm, per_source=False):
+    def flux2mu(self, flux_norm, fitparam_values=None, per_source=False):
         """Converts the given flux model normalization to the corresponding number of signal events in the detector.
 
         Parameters
         ----------
         flux_norm : float
             The flux model normalization to convert.
+        fitparam_values : numpy ndarray | None
+            The (N_fitparam,)-shaped 1D ndarray holding the values of the global floating fit parameters at
+            which the scaling factor should be evaluated. If ``None``, the reference flux model parameter
+            values are used.
         per_source : bool
             Whether to return the number of signal events for each source separately. Default is False.
 
@@ -1780,7 +1808,9 @@ class SingleSourceMultiDatasetLLHRatioAnalysis(LLHRatioAnalysis):
         float | (n_sources,)-shaped numpy ndarray
             The corresponding number of signal events in the detector for the given flux model normalization.
         """
-        return flux_norm / self.calculate_fluxmodel_scaling_factor(per_source=per_source)
+        return flux_norm / self.calculate_fluxmodel_scaling_factor(
+            fitparam_values=fitparam_values, per_source=per_source
+        )
 
 
 class MultiSourceMultiDatasetLLHRatioAnalysis(LLHRatioAnalysis):

--- a/skyllh/core/analysis.py
+++ b/skyllh/core/analysis.py
@@ -380,6 +380,22 @@ class Analysis(
         for component in self._iter_energy_range_capable():
             component.energy_range = value
 
+    def _has_explicit_energy_range_cut(self):
+        """Returns True if an explicit energy range cut is configured at the
+        analysis level or directly on any energy-range-capable component."""
+        if self.sig_gen_energy_range_is_set:
+            return True
+        for component in self._iter_energy_range_capable():
+            # PDDatasetSignalGenerator uses _input_range to distinguish an
+            # explicit cut from the full-range default. Mirror the same pattern
+            # used in MultiDatasetSignalGenerator.fluxmodel_scaling_factor.
+            if hasattr(component, '_input_range'):
+                if component._input_range is not None:
+                    return True
+            elif component.energy_range is not None:
+                return True
+        return False
+
     @property
     def energy_range(self):
         """Configured true-energy range for signal generation in GeV.
@@ -411,7 +427,7 @@ class Analysis(
     @energy_range.setter
     def energy_range(self, value):
         self.sig_gen_energy_range = value
-        self.sig_gen_energy_range_is_set = True
+        self.sig_gen_energy_range_is_set = value is not None
         self._apply_energy_range(value)
 
     @property
@@ -1752,7 +1768,7 @@ class SingleSourceMultiDatasetLLHRatioAnalysis(LLHRatioAnalysis):
                 'The configured signal generator does not implement the fluxmodel_scaling_factor interface!'
             )
 
-        if fitparam_values is not None and self.sig_gen_energy_range is not None:
+        if fitparam_values is not None and self._has_explicit_energy_range_cut():
             raise NotImplementedError(
                 'The calculate_fluxmodel_scaling_factor does not support fitparam_values when an energy_range '
                 'is configured on the analysis. The energy range correction factors are precomputed at the '

--- a/skyllh/core/signal_generator.py
+++ b/skyllh/core/signal_generator.py
@@ -298,7 +298,7 @@ class MultiDatasetSignalGenerator(
         for sig_generator in filter(None, self.sig_generator_list):
             sig_generator.change_shg_mgr(shg_mgr=shg_mgr)
 
-    def fluxmodel_scaling_factor(self, per_source=False):
+    def fluxmodel_scaling_factor(self, src_params_recarray=None, per_source=False):
         """Returns the scaling factor to convert a mean number of detected
         signal events into a flux normalization.
 
@@ -308,6 +308,11 @@ class MultiDatasetSignalGenerator(
 
         Parameters
         ----------
+        src_params_recarray : numpy structured ndarray | None
+            The (N_sources,)-shaped structured ndarray holding the local source parameter values to use for
+            the detector signal yield calculation. When provided, this overrides the internally cached
+            reference parameter array for this call only (the cache is not updated).
+            If ``None``, the cached reference parameter values built from the flux model defaults are used.
         per_source : bool
             If set to True, return per-source scaling factors that sum to the global scaling factor. If set to False,
             return the global scaling factor.
@@ -320,12 +325,14 @@ class MultiDatasetSignalGenerator(
         """
         src_detsigyield_weights_service = self.ds_sig_weight_factors_service.src_detsigyield_weights_service
 
-        if self._src_params_recarray is None:
-            self._src_params_recarray = self.create_src_params_recarray(
-                src_detsigyield_weights_service=src_detsigyield_weights_service
-            )
+        if src_params_recarray is None:
+            if self._src_params_recarray is None:
+                self._src_params_recarray = self.create_src_params_recarray(
+                    src_detsigyield_weights_service=src_detsigyield_weights_service
+                )
+            src_params_recarray = self._src_params_recarray
 
-        src_detsigyield_weights_service.calculate(src_params_recarray=self._src_params_recarray)
+        src_detsigyield_weights_service.calculate(src_params_recarray=src_params_recarray)
         (a_jk, _) = src_detsigyield_weights_service.get_weights()
 
         # Apply optional per-dataset/source correction factors for specialized generators.
@@ -746,7 +753,7 @@ class MCMultiDatasetSignalGenerator(
 
         self._construct_signal_candidates()
 
-    def fluxmodel_scaling_factor(self, per_source=False):
+    def fluxmodel_scaling_factor(self, src_params_recarray=None, per_source=False):
         """Scaling factor to convert a mean number of signal events (mu) into a flux normalization as per the
         definition of the flux models of the source hypothesis groups.
 
@@ -756,6 +763,11 @@ class MCMultiDatasetSignalGenerator(
 
         Parameters
         ----------
+        src_params_recarray : numpy structured ndarray | None
+            Must be ``None``. Providing a non-``None`` value raises :class:`NotImplementedError` because this
+            generator derives its scaling factor from precomputed MC signal candidates rather than from a
+            detector signal yield calculation and therefore cannot be re-evaluated at arbitrary parameter values
+            without regenerating those candidates.
         per_source : bool
             Flag if the scaling factors should be returned for each source individually (True), or as the sum of all
             these factors (False). The default is False.
@@ -767,6 +779,13 @@ class MCMultiDatasetSignalGenerator(
             signal event into a flux normalization for the given signal hypothesis. If `per_source` is set to True,
             a numpy ndarray is returned that contains the flux for each individual source.
         """
+        if src_params_recarray is not None:
+            raise NotImplementedError(
+                'MCMultiDatasetSignalGenerator.fluxmodel_scaling_factor does not support src_params_recarray '
+                '/ fitparam_values. The scaling factor is derived from precomputed MC signal candidates and '
+                'cannot be re-evaluated at arbitrary parameter values without regenerating those candidates.'
+            )
+
         logger.warning(
             'The fluxmodel_scaling_factor method of the MCMultiDatasetSignalGenerator class is currently only '
             'implemented for the case of a single source or for multiple sources with the same flux model. '

--- a/tests/core/test_signal_generator.py
+++ b/tests/core/test_signal_generator.py
@@ -43,6 +43,8 @@ from skyllh.i3.signal_generation import (
 
 DATA_SAMPLES_IMPORTED = tool.is_available('i3skyllh')
 
+_GAMMA_RECARRAY_DTYPE = [('gamma', np.float64), ('gamma:gpidx', np.int32)]
+
 
 def create_signal_generator(
     cfg,
@@ -236,7 +238,7 @@ class TestMultiDatasetSignalGeneratorEnergyRangeConsistency(unittest.TestCase):
     def _make_sig_gen(configured_ranges):
         sig_gen = MultiDatasetSignalGenerator.__new__(MultiDatasetSignalGenerator)
         sig_gen._shg_mgr = _DummyShgMgr(n_sources=2)
-        sig_gen._src_params_recarray = np.zeros((2,), dtype=[('gamma', np.float64), ('gamma:gpidx', np.int32)])
+        sig_gen._src_params_recarray = np.zeros((2,), dtype=_GAMMA_RECARRAY_DTYPE)
         src_service = _DummySrcDetSigYieldWeightsService(a_jk=np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float64))
         sig_gen._ds_sig_weight_factors_service = _DummyDatasetSignalWeightFactorsService(src_service=src_service)
         sig_gen._sig_generator_list = [
@@ -275,7 +277,7 @@ class TestMultiDatasetSignalGeneratorEnergyRangeConsistency(unittest.TestCase):
 class TestMultiDatasetSignalGeneratorKwargPolicy(unittest.TestCase):
     def test_generate_signal_events_rejects_energy_range_kwarg(self):
         sig_gen = MultiDatasetSignalGenerator.__new__(MultiDatasetSignalGenerator)
-        sig_gen._src_params_recarray = np.zeros((1,), dtype=[('gamma', np.float64), ('gamma:gpidx', np.int32)])
+        sig_gen._src_params_recarray = np.zeros((1,), dtype=_GAMMA_RECARRAY_DTYPE)
 
         src_service = _DummySrcDetSigYieldWeightsService(a_jk=np.array([[1.0], [1.0]], dtype=np.float64))
         sig_gen._ds_sig_weight_factors_service = _DummyDatasetSignalWeightFactorsService(
@@ -304,6 +306,29 @@ class TestMultiDatasetSignalGeneratorKwargPolicy(unittest.TestCase):
 
         self.assertIsNone(ds_gen_0.last_generate_kwargs)
         self.assertIsNone(ds_gen_1.last_generate_kwargs)
+
+
+class TestMCMultiDatasetSignalGeneratorSrcParamsRecarrayParam(unittest.TestCase):
+    """Unit tests for the src_params_recarray guard in MCMultiDatasetSignalGenerator."""
+
+    def test_raises_not_implemented_when_src_params_recarray_provided(self):
+        """Providing a non-None src_params_recarray raises NotImplementedError."""
+        sig_gen = MCMultiDatasetSignalGenerator.__new__(MCMultiDatasetSignalGenerator)
+        recarray = np.zeros((1,), dtype=_GAMMA_RECARRAY_DTYPE)
+
+        with self.assertRaises(NotImplementedError):
+            sig_gen.fluxmodel_scaling_factor(src_params_recarray=recarray)
+
+    def test_none_src_params_recarray_does_not_raise_not_implemented(self):
+        """src_params_recarray=None (default) must not raise NotImplementedError."""
+        sig_gen = MCMultiDatasetSignalGenerator.__new__(MCMultiDatasetSignalGenerator)
+
+        try:
+            sig_gen.fluxmodel_scaling_factor(src_params_recarray=None)
+        except NotImplementedError:
+            self.fail('fluxmodel_scaling_factor raised NotImplementedError with src_params_recarray=None')
+        except Exception:
+            pass  # Other errors are expected since the generator is uninitialized.
 
 
 if __name__ == '__main__':

--- a/tests/publicdata_ps/test_time_integrated_ps.py
+++ b/tests/publicdata_ps/test_time_integrated_ps.py
@@ -167,12 +167,41 @@ class AnalysisWithEnergyRangeTestCase(unittest.TestCase):
         )
         cls.ana_post_set.energy_range = cls.ENERGY_RANGE
 
-        # Analysis 3: dedicated instance for the energy_range change-and-restore test.
+        # Analysis 3: energy_range change-and-restore test.
         cls.ana_mutable = create_analysis(
             cfg=cls.cfg,
             datasets=cls.datasets,
             source=cls.source,
             energy_range=cls.ENERGY_RANGE,
+        )
+
+        # Analysis 4: energy_range set directly on each dataset signal generator after construction.
+        cls.ana_direct_sig_gen = create_analysis(
+            cfg=cls.cfg,
+            datasets=cls.datasets,
+            source=cls.source,
+        )
+        cls.ana_direct_sig_gen.construct_signal_generator()
+        for gen in cls.ana_direct_sig_gen._sig_generator.sig_generator_list:
+            if hasattr(gen, 'energy_range'):
+                gen.energy_range = cls.ENERGY_RANGE
+
+        # Analysis 5: energy_range set then reset to None correctly clears sig_gen_energy_range_is_set.
+        cls.ana_resettable = create_analysis(
+            cfg=cls.cfg,
+            datasets=cls.datasets,
+            source=cls.source,
+            energy_range=cls.ENERGY_RANGE,
+        )
+        cls.ana_resettable.energy_range = None
+
+        # Analysis 6: bin-aligned equivalent of ENERGY_RANGE.
+        cls.ENERGY_RANGE_NOT_BIN_ALIGNED = (1.2e3, 8e5)
+        cls.ana_not_bin_aligned = create_analysis(
+            cfg=cls.cfg,
+            datasets=cls.datasets,
+            source=cls.source,
+            energy_range=cls.ENERGY_RANGE_NOT_BIN_ALIGNED,
         )
 
     def setUp(self):
@@ -218,6 +247,25 @@ class AnalysisWithEnergyRangeTestCase(unittest.TestCase):
         np.testing.assert_allclose(res1['ns'], res2['ns'], rtol=1e-10)
         np.testing.assert_allclose(res1['gamma'], res2['gamma'], rtol=1e-10)
 
+    def test_non_bin_aligned_matches_bin_aligned_equivalent(self):
+        """A non-bin-aligned energy_range and its bin-aligned equivalent must produce identical results"""
+        np.testing.assert_allclose(
+            self.ana.calculate_fluxmodel_scaling_factor(),
+            self.ana_not_bin_aligned.calculate_fluxmodel_scaling_factor(),
+            rtol=1e-10,
+        )
+
+        rss1 = RandomStateService(seed=1)
+        res1 = self.ana.do_trial(rss=rss1, mean_n_sig=40)[0]
+
+        rss2 = RandomStateService(seed=1)
+        res2 = self.ana_not_bin_aligned.do_trial(rss=rss2, mean_n_sig=40)[0]
+
+        np.testing.assert_equal(res1['n_sig'], res2['n_sig'])
+        np.testing.assert_allclose(res1['ts'], res2['ts'], rtol=1e-10)
+        np.testing.assert_allclose(res1['ns'], res2['ns'], rtol=1e-10)
+        np.testing.assert_allclose(res1['gamma'], res2['gamma'], rtol=1e-10)
+
     def test_energy_range_change_after_trial(self):
         """Changing energy_range mid-use and restoring it reproduces the original do_trial result."""
         # First trial with initial energy_range.
@@ -257,6 +305,38 @@ class AnalysisWithEnergyRangeTestCase(unittest.TestCase):
         # The energy_range is set as ana.energy_range property.
         with self.assertRaises(NotImplementedError):
             self.ana_post_set.calculate_fluxmodel_scaling_factor(fitparam_values=fitparam_values)
+
+    def test_fitparam_values_with_direct_sig_gen_energy_range_raises(self):
+        """Setting energy_range directly on per-dataset signal generators must also raise
+        NotImplementedError when fitparam_values is provided, because correction factors are stale."""
+        fitparam_values = np.zeros(self.ana_direct_sig_gen._pmm.n_global_floating_params, dtype=np.float64)
+        fitparam_values[self.ana_direct_sig_gen._pmm.get_gflp_idx('gamma')] = 3.0
+
+        with self.assertRaises(NotImplementedError):
+            self.ana_direct_sig_gen.calculate_fluxmodel_scaling_factor(fitparam_values=fitparam_values)
+
+    def test_energy_range_reset_to_none_clears_flag_and_unblocks_fitparam_values(self):
+        """Resetting energy_range to None must clear sig_gen_energy_range_is_set
+        and allow fitparam_values to be used again without raising."""
+        self.assertFalse(self.ana_resettable.sig_gen_energy_range_is_set)
+        self.assertIsNone(self.ana_resettable.sig_gen_energy_range)
+
+        fitparam_values = np.zeros(self.ana_resettable._pmm.n_global_floating_params, dtype=np.float64)
+        fitparam_values[self.ana_resettable._pmm.get_gflp_idx('gamma')] = 3.0
+
+        # Must not raise — the energy range guard was cleared by the reset.
+        result = self.ana_resettable.calculate_fluxmodel_scaling_factor(fitparam_values=fitparam_values)
+        self.assertIsNotNone(result)
+        self.assertGreater(result, 0)
+
+        # After reset, the scaling factor must differ from the one computed with the energy range still active.
+        scaling_reset = self.ana_resettable.calculate_fluxmodel_scaling_factor()
+        scaling_with_range = self.ana.calculate_fluxmodel_scaling_factor()
+        ratio = scaling_reset / scaling_with_range
+        self.assertFalse(
+            np.isclose(ratio, 1.0, rtol=0.05),
+            msg=f'Scaling factors should differ after energy_range reset, but ratio={ratio:.4g} is within 5% of 1.',
+        )
 
     def test_mu2flux_flux2mu_consistency(self):
         """mu2flux and flux2mu are mutual inverses, and both analyses agree on all flux values."""

--- a/tests/publicdata_ps/test_time_integrated_ps.py
+++ b/tests/publicdata_ps/test_time_integrated_ps.py
@@ -379,8 +379,6 @@ class FitparamValuesTestCase(unittest.TestCase):
 
     def test_ana_with_fitparam_values_matches_ana_ref(self):
         """Using fitparam_values with ana should match the reference analysis without fitparam_values."""
-        print(self.ana.sig_gen_energy_range)
-        print(self.ana.sig_gen_energy_range_is_set)
         flux1 = self.ana.mu2flux(10, fitparam_values=self._fitparam_values(2.122526))
         flux2 = self.ana_ref.mu2flux(10)
         np.testing.assert_allclose(flux1, flux2, rtol=1e-10)

--- a/tests/publicdata_ps/test_time_integrated_ps.py
+++ b/tests/publicdata_ps/test_time_integrated_ps.py
@@ -244,6 +244,20 @@ class AnalysisWithEnergyRangeTestCase(unittest.TestCase):
         np.testing.assert_allclose(res1['ns'], res3['ns'], rtol=1e-10)
         np.testing.assert_allclose(res1['gamma'], res3['gamma'], rtol=1e-10)
 
+    def test_fitparam_values_with_energy_range_raises(self):
+        """Combining fitparam_values with a configured energy_range raises NotImplementedError because
+        the energy range correction factors are precomputed at reference parameters and would be stale."""
+        fitparam_values = np.zeros(self.ana._pmm.n_global_floating_params, dtype=np.float64)
+        fitparam_values[self.ana._pmm.get_gflp_idx('gamma')] = 3.0
+
+        # The energy_range is set as create_analysis parameter.
+        with self.assertRaises(NotImplementedError):
+            self.ana.calculate_fluxmodel_scaling_factor(fitparam_values=fitparam_values)
+
+        # The energy_range is set as ana.energy_range property.
+        with self.assertRaises(NotImplementedError):
+            self.ana_post_set.calculate_fluxmodel_scaling_factor(fitparam_values=fitparam_values)
+
     def test_mu2flux_flux2mu_consistency(self):
         """mu2flux and flux2mu are mutual inverses, and both analyses agree on all flux values."""
         mu_in = 10.0
@@ -255,6 +269,121 @@ class AnalysisWithEnergyRangeTestCase(unittest.TestCase):
         # Both analyses must agree on mu2flux and flux2mu
         np.testing.assert_allclose(self.ana.mu2flux(mu_in), self.ana_post_set.mu2flux(mu_in), rtol=1e-10)
         np.testing.assert_allclose(self.ana.flux2mu(flux_norm), self.ana_post_set.flux2mu(flux_norm), rtol=1e-10)
+
+
+class FitparamValuesTestCase(unittest.TestCase):
+    """Integration tests for the fitparam_values parameter of calculate_fluxmodel_scaling_factor,
+    mu2flux, and flux2mu on SingleSourceMultiDatasetLLHRatioAnalysis.
+
+    The publicdata_ps analysis has two global floating parameters in this order:
+      index 0: ns   (mapped to detector model — does not affect the flux scaling factor)
+      index 1: gamma (mapped to source — determines the detector signal yield)
+    The reference gamma embedded in the flux model is 2.0 (refplflux_gamma default).
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.cfg = Config()
+        cls.cfg['repository']['base_path'] = os.path.join(os.getcwd(), '.repository')
+
+        dsc = PublicData_10y_ps.create_dataset_collection(cfg=cls.cfg)
+        cls.datasets = dsc[
+            'IC40',
+            'IC59',
+            'IC79',
+            'IC86_I',
+            'IC86_II-VII',
+        ]
+
+        for ds in cls.datasets:
+            if not ds.make_data_available():
+                raise RuntimeError(f'The data of dataset {ds.name} could not be made available!')
+
+        cls.source = PointLikeSource(name='point-source', ra=np.radians(77.358), dec=np.radians(5.693), weight=1)
+
+        cls.ana = create_analysis(
+            cfg=cls.cfg,
+            datasets=cls.datasets,
+            source=cls.source,
+        )
+
+        # The reference gamma is 2.122526, which is the best-fit gamma obtained in test_unblind() with the default analysis configuration.
+        cls.ana_ref = create_analysis(
+            cfg=cls.cfg,
+            datasets=cls.datasets,
+            source=cls.source,
+            refplflux_gamma=2.122526,
+        )
+
+        # PMM order: [ns, gamma]. The flux model reference gamma is 2.0.
+        cls.GAMMA_IDX = cls.ana._pmm.get_gflp_idx(name='gamma')
+        cls.N_PARAMS = cls.ana._pmm.n_global_floating_params
+        cls.REF_GAMMA = 2.0
+
+    def _fitparam_values(self, gamma):
+        """Build a fitparam_values array with the given gamma; ns is set to zero."""
+        values = np.zeros(self.N_PARAMS, dtype=np.float64)
+        values[self.GAMMA_IDX] = gamma
+        return values
+
+    def test_fitparam_values_at_reference_gamma_matches_default(self):
+        """calculate_fluxmodel_scaling_factor() and the same call with fitparam_values at the
+        reference gamma must return equal results."""
+        scaling_default = self.ana.calculate_fluxmodel_scaling_factor()
+        scaling_ref = self.ana.calculate_fluxmodel_scaling_factor(fitparam_values=self._fitparam_values(self.REF_GAMMA))
+        np.testing.assert_allclose(scaling_ref, scaling_default, rtol=1e-10)
+
+    def test_fitparam_values_different_gamma_changes_scaling_factor(self):
+        """Providing a gamma different from the reference must return a different scaling factor."""
+        scaling_default = self.ana.calculate_fluxmodel_scaling_factor()
+        scaling_alt = self.ana.calculate_fluxmodel_scaling_factor(fitparam_values=self._fitparam_values(3.0))
+        self.assertFalse(
+            np.isclose(scaling_default, scaling_alt, atol=0, rtol=1e-10),
+            msg=f'Expected scaling factors to differ but got {scaling_default} and {scaling_alt}',
+        )
+
+    def test_default_cache_unchanged_after_fitparam_call(self):
+        """Calling with fitparam_values must not alter the signal generator's cached reference state.
+        A subsequent default call must reproduce the original scaling factor."""
+        scaling_before = self.ana.calculate_fluxmodel_scaling_factor()
+
+        # Call with a non-reference gamma to exercise the custom-params path.
+        self.ana.calculate_fluxmodel_scaling_factor(fitparam_values=self._fitparam_values(3.0))
+
+        scaling_after = self.ana.calculate_fluxmodel_scaling_factor()
+        np.testing.assert_allclose(scaling_after, scaling_before, rtol=1e-10)
+
+    def test_mu2flux_with_fitparam_values_consistent(self):
+        """mu2flux(mu, fitparam_values=...) equals calculate_fluxmodel_scaling_factor(fitparam_values=...) * mu."""
+        mu = 25.0
+        fv = self._fitparam_values(3.0)
+        expected = self.ana.calculate_fluxmodel_scaling_factor(fitparam_values=fv) * mu
+        result = self.ana.mu2flux(mu, fitparam_values=fv)
+        np.testing.assert_allclose(result, expected, rtol=1e-10)
+
+    def test_flux2mu_with_fitparam_values_consistent(self):
+        """flux2mu(flux_norm, fitparam_values=...) equals flux_norm / calculate_fluxmodel_scaling_factor(fitparam_values=...)."""
+        flux_norm = 1e-12
+        fv = self._fitparam_values(3.0)
+        expected = flux_norm / self.ana.calculate_fluxmodel_scaling_factor(fitparam_values=fv)
+        result = self.ana.flux2mu(flux_norm, fitparam_values=fv)
+        np.testing.assert_allclose(result, expected, rtol=1e-10)
+
+    def test_mu2flux_flux2mu_roundtrip_with_fitparam_values(self):
+        """flux2mu(mu2flux(mu, fitparam_values=...), fitparam_values=...) recovers mu."""
+        mu = 15.0
+        fv = self._fitparam_values(3.0)
+        flux_norm = self.ana.mu2flux(mu, fitparam_values=fv)
+        mu_recovered = self.ana.flux2mu(flux_norm, fitparam_values=fv)
+        np.testing.assert_allclose(mu_recovered, mu, rtol=1e-10)
+
+    def test_ana_with_fitparam_values_matches_ana_ref(self):
+        """Using fitparam_values with ana should match the reference analysis without fitparam_values."""
+        print(self.ana.sig_gen_energy_range)
+        print(self.ana.sig_gen_energy_range_is_set)
+        flux1 = self.ana.mu2flux(10, fitparam_values=self._fitparam_values(2.122526))
+        flux2 = self.ana_ref.mu2flux(10)
+        np.testing.assert_allclose(flux1, flux2, rtol=1e-10)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
It seems to work as the new `Using fitparam_values with ana should match the reference analysis without fitparam_values` test passes:
https://github.com/icecube/skyllh/blob/b56df81f12f706c77404096b3b7c721e807b88e7/tests/publicdata_ps/test_time_integrated_ps.py#L380