### PR TITLE
Load sm once

### DIFF
--- a/skyllh/analyses/i3/publicdata_ps/mcbkg_ps.py
+++ b/skyllh/analyses/i3/publicdata_ps/mcbkg_ps.py
@@ -24,6 +24,9 @@ from skyllh.analyses.i3.publicdata_ps.signal_generator import (
 from skyllh.analyses.i3.publicdata_ps.signalpdf import (
     PDSignalEnergyPDFSet,
 )
+from skyllh.analyses.i3.publicdata_ps.smearing_matrix import (
+    PDSmearingMatrix,
+)
 from skyllh.analyses.i3.publicdata_ps.utils import (
     create_energy_cut_spline,
 )
@@ -311,9 +314,13 @@ def create_analysis(
         spatial_bkgpdf = DataBackgroundI3SpatialPDF(data_exp=data.exp, sin_dec_binning=sin_dec_binning)
         spatial_pdfratio = SigOverBkgPDFRatio(sig_pdf=spatial_sigpdf, bkg_pdf=spatial_bkgpdf)
 
+        sm = PDSmearingMatrix(
+            pathfilenames=ds.get_abs_pathfilename_list(ds.get_aux_data_definition('smearing_datafile'))
+        )
+
         # Create the energy PDF ratio instance for this dataset.
         energy_sigpdfset = PDSignalEnergyPDFSet(
-            ds=ds, src_dec=source.dec, fluxmodel=fluxmodel, param_grid_set=gamma_grid, ppbar=ppbar
+            ds=ds, src_dec=source.dec, fluxmodel=fluxmodel, param_grid_set=gamma_grid, ppbar=ppbar, sm=sm
         )
 
         bkg_pdf_pathfilename = ds.get_abs_pathfilename_list(ds.get_aux_data_definition('pdf_bkg_datafile'))[0]
@@ -342,6 +349,7 @@ def create_analysis(
             ds_idx=ds_idx,
             energy_cut_spline=energy_cut_spline,
             cut_sindec=cut_sindec[ds_idx],
+            sm=sm,
         )
 
         ana.add_dataset(

--- a/skyllh/analyses/i3/publicdata_ps/signal_generator.py
+++ b/skyllh/analyses/i3/publicdata_ps/signal_generator.py
@@ -58,6 +58,7 @@ class PDDatasetSignalGenerator(
         energy_cut_spline=None,
         cut_sindec=None,
         energy_range=None,
+        sm=None,
         **kwargs,
     ):
         """Creates a new instance of the signal generator for generating
@@ -82,6 +83,9 @@ class PDDatasetSignalGenerator(
         energy_range : 2-element tuple of float | None
             The energy range in which signal events should be generated.
             If set to None, the full energy range (1e2 - 1e9 GeV) is used.
+        sm : instance of PDSmearingMatrix | None
+            A pre-loaded smearing matrix to reuse. If ``None``, the matrix is
+            loaded from the dataset's auxiliary data files.
         """
         super().__init__(shg_mgr=shg_mgr, **kwargs)
 
@@ -91,9 +95,12 @@ class PDDatasetSignalGenerator(
         self.ds_idx = ds_idx
         self.energy_cut_spline = energy_cut_spline
         self.cut_sindec = cut_sindec
-        self.sm = PDSmearingMatrix(
-            pathfilenames=ds.get_abs_pathfilename_list(ds.get_aux_data_definition('smearing_datafile'))
-        )
+        if sm is None:
+            # Load the smearing matrix.
+            sm = PDSmearingMatrix(
+                pathfilenames=ds.get_abs_pathfilename_list(ds.get_aux_data_definition('smearing_datafile'))
+            )
+        self.sm = sm
 
         # Cache effective-area data reused for correction-factor calculations.
         self._aeff_pathfilenames = ds.get_abs_pathfilename_list(ds.get_aux_data_definition('eff_area_datafile'))

--- a/skyllh/analyses/i3/publicdata_ps/signalpdf.py
+++ b/skyllh/analyses/i3/publicdata_ps/signalpdf.py
@@ -175,6 +175,7 @@ class PDSignalEnergyPDFSet(
         param_grid_set,
         ncpu=None,
         ppbar=None,
+        sm=None,
         **kwargs,
     ):
         """Creates a new PDSignalEnergyPDFSet instance for the public data.
@@ -196,6 +197,9 @@ class PDSignalEnergyPDFSet(
             not specified, i.e. set to None.
         ppbar : instance of ProgressBar | None
             The instance of ProgressBar for the optional parent progress bar.
+        sm : instance of PDSmearingMatrix | None
+            A pre-loaded smearing matrix to reuse. If ``None``, the matrix is
+            loaded from the dataset's auxiliary data files.
         """
         self._logger = get_logger(module_classname(self))
 
@@ -224,10 +228,11 @@ class PDSignalEnergyPDFSet(
 
         super().__init__(param_grid_set=param_grid_set, ncpu=ncpu, **kwargs)
 
-        # Load the smearing matrix.
-        sm = PDSmearingMatrix(
-            pathfilenames=ds.get_abs_pathfilename_list(ds.get_aux_data_definition('smearing_datafile'))
-        )
+        if sm is None:
+            # Load the smearing matrix.
+            sm = PDSmearingMatrix(
+                pathfilenames=ds.get_abs_pathfilename_list(ds.get_aux_data_definition('smearing_datafile'))
+            )
 
         # Select the slice of the smearing matrix corresponding to the
         # source declination band.

--- a/skyllh/analyses/i3/publicdata_ps/time_dependent_ps.py
+++ b/skyllh/analyses/i3/publicdata_ps/time_dependent_ps.py
@@ -20,6 +20,9 @@ from skyllh.analyses.i3.publicdata_ps.signal_generator import (
 from skyllh.analyses.i3.publicdata_ps.signalpdf import (
     PDSignalEnergyPDFSet,
 )
+from skyllh.analyses.i3.publicdata_ps.smearing_matrix import (
+    PDSmearingMatrix,
+)
 from skyllh.analyses.i3.publicdata_ps.utils import (
     clip_grl_start_times,
     create_energy_cut_spline,
@@ -921,9 +924,13 @@ def create_analysis(
         spatial_bkgpdf = DataBackgroundI3SpatialPDF(cfg=cfg, data_exp=data.exp, sin_dec_binning=sin_dec_binning)
         spatial_pdfratio = SigOverBkgPDFRatio(cfg=cfg, sig_pdf=spatial_sigpdf, bkg_pdf=spatial_bkgpdf)
 
+        sm = PDSmearingMatrix(
+            pathfilenames=ds.get_abs_pathfilename_list(ds.get_aux_data_definition('smearing_datafile'))
+        )
+
         # Create the energy PDF ratio instance for this dataset.
         energy_sigpdfset = PDSignalEnergyPDFSet(
-            cfg=cfg, ds=ds, src_dec=source.dec, fluxmodel=fluxmodel, param_grid_set=gamma_grid, ppbar=ppbar
+            cfg=cfg, ds=ds, src_dec=source.dec, fluxmodel=fluxmodel, param_grid_set=gamma_grid, ppbar=ppbar, sm=sm
         )
         smoothing_filter = BlockSmoothingFilter(nbins=1)
         energy_bkgpdf = PDDataBackgroundI3EnergyPDF(
@@ -988,6 +995,7 @@ def create_analysis(
             livetime=livetime,
             time_flux_profile=time_flux_profile,
             energy_cut_spline=energy_cut_spline,
+            sm=sm,
         )
 
         ana.add_dataset(

--- a/skyllh/analyses/i3/publicdata_ps/time_integrated_ps.py
+++ b/skyllh/analyses/i3/publicdata_ps/time_integrated_ps.py
@@ -21,6 +21,9 @@ from skyllh.analyses.i3.publicdata_ps.signal_generator import (
 from skyllh.analyses.i3.publicdata_ps.signalpdf import (
     PDSignalEnergyPDFSet,
 )
+from skyllh.analyses.i3.publicdata_ps.smearing_matrix import (
+    PDSmearingMatrix,
+)
 from skyllh.analyses.i3.publicdata_ps.utils import (
     create_energy_cut_spline,
 )
@@ -344,9 +347,13 @@ def create_analysis(
         spatial_bkgpdf = DataBackgroundI3SpatialPDF(cfg=cfg, data_exp=data.exp, sin_dec_binning=sin_dec_binning)
         spatial_pdfratio = SigOverBkgPDFRatio(cfg=cfg, sig_pdf=spatial_sigpdf, bkg_pdf=spatial_bkgpdf)
 
+        sm = PDSmearingMatrix(
+            pathfilenames=ds.get_abs_pathfilename_list(ds.get_aux_data_definition('smearing_datafile'))
+        )
+
         # Create the energy PDF ratio instance for this dataset.
         energy_sigpdfset = PDSignalEnergyPDFSet(
-            cfg=cfg, ds=ds, src_dec=source.dec, fluxmodel=fluxmodel, param_grid_set=gamma_grid, ppbar=ppbar
+            cfg=cfg, ds=ds, src_dec=source.dec, fluxmodel=fluxmodel, param_grid_set=gamma_grid, ppbar=ppbar, sm=sm
         )
         smoothing_filter = BlockSmoothingFilter(nbins=1)
         energy_bkgpdf = PDDataBackgroundI3EnergyPDF(
@@ -387,6 +394,7 @@ def create_analysis(
             ds=ds,
             ds_idx=ds_idx,
             energy_cut_spline=energy_cut_spline,
+            sm=sm,
         )
 
         ana.add_dataset(

--- a/skyllh/analyses/i3/publicdata_ps/time_integrated_ps_function_energy_spectrum.py
+++ b/skyllh/analyses/i3/publicdata_ps/time_integrated_ps_function_energy_spectrum.py
@@ -21,6 +21,9 @@ from skyllh.analyses.i3.publicdata_ps.signal_generator import (
 from skyllh.analyses.i3.publicdata_ps.signalpdf import (
     PDSignalEnergyPDFSet,
 )
+from skyllh.analyses.i3.publicdata_ps.smearing_matrix import (
+    PDSmearingMatrix,
+)
 from skyllh.analyses.i3.publicdata_ps.utils import (
     create_energy_cut_spline,
 )
@@ -388,9 +391,13 @@ def create_analysis(
         spatial_bkgpdf = DataBackgroundI3SpatialPDF(cfg=cfg, data_exp=data.exp, sin_dec_binning=sin_dec_binning)
         spatial_pdfratio = SigOverBkgPDFRatio(cfg=cfg, sig_pdf=spatial_sigpdf, bkg_pdf=spatial_bkgpdf)
 
+        sm = PDSmearingMatrix(
+            pathfilenames=ds.get_abs_pathfilename_list(ds.get_aux_data_definition('smearing_datafile'))
+        )
+
         # Create the energy PDF ratio instance for this dataset.
         energy_sigpdfset = PDSignalEnergyPDFSet(
-            cfg=cfg, ds=ds, src_dec=source.dec, fluxmodel=fluxmodel, param_grid_set=e_peak_grid, ppbar=ppbar
+            cfg=cfg, ds=ds, src_dec=source.dec, fluxmodel=fluxmodel, param_grid_set=e_peak_grid, ppbar=ppbar, sm=sm
         )
         smoothing_filter = BlockSmoothingFilter(nbins=1)
         energy_bkgpdf = PDDataBackgroundI3EnergyPDF(
@@ -431,6 +438,7 @@ def create_analysis(
             ds=ds,
             ds_idx=ds_idx,
             energy_cut_spline=energy_cut_spline,
+            sm=sm,
         )
 
         ana.add_dataset(


### PR DESCRIPTION
In addition to https://github.com/icecube/skyllh/pull/316 this PR decreases `create_analysis` call from 24s to ~13s.

Reading large csv files takes a long time, therefore we can optimise by loading the smearing matrix only once per dataset with minimal complexity increase.