### PR TITLE
Minor fix to tutorials

### DIFF
--- a/doc/sphinx/tutorials/fitting_a_source.ipynb
+++ b/doc/sphinx/tutorials/fitting_a_source.ipynb
@@ -799,9 +799,7 @@
    "id": "bce532ef",
    "metadata": {},
    "source": [
-    "Note that the ``ana.unblind`` method runs the analysis on the experimental data.\n",
-    "\n",
-    "The methods to generate and analyze pseudo-data are illustrated in the `generating_pseudo_experiments.ipynb` notebook."
+    "Note that the ``ana.unblind`` method runs the analysis on the experimental data."
    ]
   },
   {

--- a/doc/sphinx/tutorials/time_dependent_point_source.ipynb
+++ b/doc/sphinx/tutorials/time_dependent_point_source.ipynb
@@ -13,7 +13,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This tutorial shows how to use the public point-source data for a time dependent point-source analysis with the public 14-year IceCube point-source data. The time fit is performed by the expectation maximization (EM) algorithm.   "
+    "This tutorial shows how to use the public point-source data for a time dependent point-source analysis with the public IceTracks-DR2 (14-year) release, using the `IC86_I-XI` subset in this example. The time fit is performed by the expectation maximization (EM) algorithm."
    ]
   },
   {

--- a/doc/sphinx/tutorials/time_dependent_point_source.ipynb
+++ b/doc/sphinx/tutorials/time_dependent_point_source.ipynb
@@ -13,7 +13,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This tutorial shows how to use the public point-source data for a time dependent point-source analysis with the public 10-year IceCube point-source data. The time fit is performed by the expectation maximization (EM) algorithm.   "
+    "This tutorial shows how to use the public point-source data for a time dependent point-source analysis with the public 14-year IceCube point-source data. The time fit is performed by the expectation maximization (EM) algorithm.   "
    ]
   },
   {


### PR DESCRIPTION
- removed `The methods to generate and analyze pseudo-data are illustrated in the `generating_pseudo_experiments.ipynb` notebook.` from `doc/sphinx/tutorials/fitting_a_source.ipynb`
- updated `with the public 10-year` to 14-year in `doc/sphinx/tutorials/time_dependent_point_source.ipynb`