### PR TITLE
Cache .repository folder and simplify use of pip cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,12 +32,16 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+    - name: Cache .repository folder
+      uses: actions/cache@v5
+      with:
+        path: .repository
+        key: repository-v1
+        restore-keys: repository-
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install ".[dev]"
+      run: pip install ".[dev]"
     - name: Run tests with pytest
       env:
         ICECUBE_PASSWORD: ${{ secrets.ICECUBE_PASSWORD }}
-      run: |
-        pytest
+      run: pytest

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -23,27 +23,11 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.x'
-
-      - name: Upgrade pip
-        run: |
-          # install pip=>20.1 to use "pip cache dir"
-          python3 -m pip install --upgrade pip
-
-      - name: Get pip cache dir
-        id: pip-cache
-        run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache dependencies
-        uses: actions/cache@v5
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
+          python-version: '3.14'
+          cache: 'pip'
 
       - name: Install dependencies
-        run: python3 -m pip install ".[docs]"
+        run: pip install ".[docs]"
 
       - name: Install pandoc
         run: sudo apt-get -y install pandoc


### PR DESCRIPTION
Rerunning the job seems to have restored the cache successfully:
<img width="1413" height="508" alt="image" src="https://github.com/user-attachments/assets/f55acf2c-ad1b-43ad-b201-0977f97509cb" />

Cache artifacts be found here: https://github.com/icecube/skyllh/actions/caches

The only caveat is that when we change the (expected) content of `.repository` we should remove the cached folder in actions/caches or increment the version key so that the cache is updated.