### PR TITLE
write livetime property in load_data method

### DIFF
--- a/skyllh/i3/dataset.py
+++ b/skyllh/i3/dataset.py
@@ -304,6 +304,22 @@ class I3Dataset(
         # Load all the defined data.
         data = I3DatasetData(data=data_, data_grl=data_grl)
 
+        # Set the livetime of the dataset from the GRL data when no livetime
+        # was specified previously.
+        if data.livetime is None and data.grl is not None:
+            if 'livetime' in data.grl:
+                # The `livetime` column accounts for livetime gaps within run,
+                # therefore it is more precise than `stop` - `start`.
+                data.livetime = np.sum(data.grl['livetime'])
+            else:
+                # If `livetime` field does not exist fall back to
+                # `stop` - `start` implementation.
+                if 'start' not in data.grl:
+                    raise KeyError(f'The GRL data for dataset "{self.name}" has no data field named "start"!')
+                if 'stop' not in data.grl:
+                    raise KeyError(f'The GRL data for dataset "{self.name}" has no data field named "stop"!')
+                data.livetime = np.sum(data.grl['stop'] - data.grl['start'])
+
         return data
 
     def prepare_data(
@@ -330,22 +346,6 @@ class I3Dataset(
             The TimeLord instance that should be used to time the data
             preparation.
         """
-        # Set the livetime of the dataset from the GRL data when no livetime
-        # was specified previously.
-        if data.livetime is None and data.grl is not None:
-            if 'livetime' in data.grl:
-                # The `livetime` column accounts for livetime gaps within run,
-                # therefore it is more precise than `stop` - `start`.
-                data.livetime = np.sum(data.grl['livetime'])
-            else:
-                # If `livetime` field does not exist fall back to
-                # `stop` - `start` implementation.
-                if 'start' not in data.grl:
-                    raise KeyError(f'The GRL data for dataset "{self.name}" has no data field named "start"!')
-                if 'stop' not in data.grl:
-                    raise KeyError(f'The GRL data for dataset "{self.name}" has no data field named "stop"!')
-                data.livetime = np.sum(data.grl['stop'] - data.grl['start'])
-
         # Execute all the data preparation functions for this dataset.
         super().prepare_data(data=data, tl=tl)
 


### PR DESCRIPTION
Moving the writing of the livetime property of the I3Dataset object to the `load_data` method.

Unit tests seem to pass.